### PR TITLE
Use strtof when loading our model

### DIFF
--- a/cpp/neuralnet/desc.cpp
+++ b/cpp/neuralnet/desc.cpp
@@ -54,8 +54,9 @@ ConvLayerDesc::ConvLayerDesc(istream& in) {
     for(int x = 0; x < convXSize; x++) {
       for(int ic = 0; ic < inChannels; ic++) {
         for(int oc = 0; oc < outChannels; oc++) {
-          float w;
-          in >> w;
+          string t;
+          in >> t;
+          float w = strtof(t.c_str(), nullptr);
           CHECKFINITE(w, name);
           weights[oc * ocStride + ic * icStride + y * yStride + x * xStride] = w;
         }


### PR DESCRIPTION
istream float parsing is notably slower than reading a word and
converting it to a float with strtof.

Using this in our model loading inner loop shaves about 20-30% of the
time it takes to load our model off of the disk.