### PR TITLE
fp16 for Pascal architecture

### DIFF
--- a/cpp/neuralnet/cudabackend.cpp
+++ b/cpp/neuralnet/cudabackend.cpp
@@ -232,9 +232,9 @@ struct ConvLayer {
       dilationY,
       dilationX,
       CUDNN_CROSS_CORRELATION,
-      CUDNN_DATA_FLOAT
+      (useFP16 && !useNHWC ? CUDNN_DATA_HALF : CUDNN_DATA_FLOAT)
     ));
-    if(useFP16)
+    if(useFP16 && useNHWC)
       CUDNN_ERR(name.c_str(),cudnnSetConvolutionMathType(convolutionDescriptor, CUDNN_TENSOR_OP_MATH));
 
     convolutionAlgorithms = new cudnnConvolutionFwdAlgo_t[maxBatchSize];

--- a/cpp/neuralnet/cudabackend.cpp
+++ b/cpp/neuralnet/cudabackend.cpp
@@ -232,9 +232,9 @@ struct ConvLayer {
       dilationY,
       dilationX,
       CUDNN_CROSS_CORRELATION,
-      (useFP16 && !useNHWC ? CUDNN_DATA_HALF : CUDNN_DATA_FLOAT)
+      (useFP16 ? CUDNN_DATA_HALF : CUDNN_DATA_FLOAT)
     ));
-    if(useFP16 && useNHWC)
+    if(useFP16)
       CUDNN_ERR(name.c_str(),cudnnSetConvolutionMathType(convolutionDescriptor, CUDNN_TENSOR_OP_MATH));
 
     convolutionAlgorithms = new cudnnConvolutionFwdAlgo_t[maxBatchSize];


### PR DESCRIPTION
Hi.

I tried "cudaUseFP16 = true" on P100, which has packed fp16 multiplication.
It slowed down and was worse than "cudaUseFP16 = false".

I changed data type for cudnnSetConvolution2dDescriptor and got performance boost at large threads.
20 threads with cudaUseFP16 = true achieves nnEvals/s = 472.44, compared with original's nnEvals/s = 379.79 (cudaUseFP16 = false) and nnEvals/s = 289.20 (cudaUseFP16 = true).

In this pull request, I used cudaUseNHWC as cudaUseTensorCore though you implemented different meaning.

The below is benchmarks.

    [original cudaUseFP16 false]
    
    numSearchThreads =  1: 10 / 10 positions, visits/s = 228.45 nnEvals/s = 210.02 nnBatches/s = 210.02 avgBatchSize = 1.00 (26.3 secs) (EloDiff baseline)
    numSearchThreads =  2: 10 / 10 positions, visits/s = 250.48 nnEvals/s = 234.44 nnBatches/s = 188.38 avgBatchSize = 1.24 (24.0 secs) (EloDiff +25)
    numSearchThreads =  4: 10 / 10 positions, visits/s = 302.68 nnEvals/s = 284.76 nnBatches/s = 130.06 avgBatchSize = 2.19 (19.9 secs) (EloDiff +77)
    numSearchThreads =  6: 10 / 10 positions, visits/s = 333.61 nnEvals/s = 309.19 nnBatches/s = 98.21 avgBatchSize = 3.15 (18.1 secs) (EloDiff +97)
    numSearchThreads =  8: 10 / 10 positions, visits/s = 355.64 nnEvals/s = 332.67 nnBatches/s = 80.50 avgBatchSize = 4.13 (17.1 secs) (EloDiff +104)
    numSearchThreads = 12: 10 / 10 positions, visits/s = 378.25 nnEvals/s = 353.67 nnBatches/s = 59.68 avgBatchSize = 5.93 (16.2 secs) (EloDiff +94)
    numSearchThreads = 16: 10 / 10 positions, visits/s = 391.34 nnEvals/s = 367.23 nnBatches/s = 46.13 avgBatchSize = 7.96 (15.7 secs) (EloDiff +74)
    numSearchThreads = 20: 10 / 10 positions, visits/s = 402.34 nnEvals/s = 379.79 nnBatches/s = 37.96 avgBatchSize = 10.01 (15.4 secs) (EloDiff +52)
    numSearchThreads = 24: 10 / 10 positions, visits/s = 403.80 nnEvals/s = 383.52 nnBatches/s = 32.93 avgBatchSize = 11.65 (15.4 secs) (EloDiff +21)
    numSearchThreads = 28: 10 / 10 positions, visits/s = 403.97 nnEvals/s = 383.28 nnBatches/s = 28.86 avgBatchSize = 13.28 (15.5 secs) (EloDiff -10)
    numSearchThreads = 32: 10 / 10 positions, visits/s = 408.90 nnEvals/s = 387.97 nnBatches/s = 25.53 avgBatchSize = 15.20 (15.4 secs) (EloDiff -38)
    
    Based on some test data, each thread costs perhaps ~8 Elo holding visits fixed (by making MCTS worse).
    Based on some test data, each speed doubling gains perhaps ~250 Elo by searching deeper.
    So APPROXIMATELY based on this benchmark: 
    numSearchThreads =  1: (baseline)
    numSearchThreads =  2:   +25 Elo
    numSearchThreads =  4:   +77 Elo
    numSearchThreads =  6:   +97 Elo
    numSearchThreads =  8:  +104 Elo
    numSearchThreads = 12:   +94 Elo
    numSearchThreads = 16:   +74 Elo
    numSearchThreads = 20:   +52 Elo
    numSearchThreads = 24:   +21 Elo
    numSearchThreads = 28:   -10 Elo
    numSearchThreads = 32:   -38 Elo
    
    [original cudaUseFP16 true]
    
    numSearchThreads =  1: 10 / 10 positions, visits/s = 43.50 nnEvals/s = 40.24 nnBatches/s = 40.24 avgBatchSize = 1.00 (137.9 secs) (EloDiff baseline)
    numSearchThreads =  2: 10 / 10 positions, visits/s = 43.82 nnEvals/s = 40.75 nnBatches/s = 40.56 avgBatchSize = 1.00 (137.2 secs) (EloDiff -5)
    numSearchThreads =  4: 10 / 10 positions, visits/s = 88.67 nnEvals/s = 82.12 nnBatches/s = 40.39 avgBatchSize = 2.03 (68.0 secs) (EloDiff +233)
    numSearchThreads =  6: 10 / 10 positions, visits/s = 131.38 nnEvals/s = 122.87 nnBatches/s = 40.54 avgBatchSize = 3.03 (46.0 secs) (EloDiff +359)
    numSearchThreads =  8: 10 / 10 positions, visits/s = 172.03 nnEvals/s = 161.89 nnBatches/s = 40.19 avgBatchSize = 4.03 (35.3 secs) (EloDiff +440)
    numSearchThreads = 12: 10 / 10 positions, visits/s = 199.88 nnEvals/s = 187.78 nnBatches/s = 31.50 avgBatchSize = 5.96 (30.6 secs) (EloDiff +462)
    numSearchThreads = 16: 10 / 10 positions, visits/s = 250.79 nnEvals/s = 235.05 nnBatches/s = 29.97 avgBatchSize = 7.84 (24.5 secs) (EloDiff +512)
    numSearchThreads = 20: 10 / 10 positions, visits/s = 309.72 nnEvals/s = 289.20 nnBatches/s = 28.77 avgBatchSize = 10.05 (20.0 secs) (EloDiff +556)
    numSearchThreads = 24: 10 / 10 positions, visits/s = 294.63 nnEvals/s = 279.49 nnBatches/s = 23.22 avgBatchSize = 12.04 (21.1 secs) (EloDiff +506)
    numSearchThreads = 28: 10 / 10 positions, visits/s = 306.52 nnEvals/s = 291.52 nnBatches/s = 21.27 avgBatchSize = 13.71 (20.5 secs) (EloDiff +488)
    numSearchThreads = 32: 10 / 10 positions, visits/s = 318.21 nnEvals/s = 302.02 nnBatches/s = 19.42 avgBatchSize = 15.56 (19.8 secs) (EloDiff +470)
    
    Based on some test data, each thread costs perhaps ~8 Elo holding visits fixed (by making MCTS worse).
    Based on some test data, each speed doubling gains perhaps ~250 Elo by searching deeper.
    So APPROXIMATELY based on this benchmark: 
    numSearchThreads =  1: (baseline)
    numSearchThreads =  2:    -5 Elo
    numSearchThreads =  4:  +233 Elo
    numSearchThreads =  6:  +359 Elo
    numSearchThreads =  8:  +440 Elo
    numSearchThreads = 12:  +462 Elo
    numSearchThreads = 16:  +512 Elo
    numSearchThreads = 20:  +556 Elo
    numSearchThreads = 24:  +506 Elo
    numSearchThreads = 28:  +488 Elo
    numSearchThreads = 32:  +470 Elo
    
    [modified cudaUseFP16 true]
    
    numSearchThreads =  1: 10 / 10 positions, visits/s = 68.45 nnEvals/s = 64.67 nnBatches/s = 64.67 avgBatchSize = 1.00 (87.6 secs) (EloDiff baseline)
    numSearchThreads =  2: 10 / 10 positions, visits/s = 74.60 nnEvals/s = 69.26 nnBatches/s = 65.46 avgBatchSize = 1.06 (80.6 secs) (EloDiff +23)
    numSearchThreads =  4: 10 / 10 positions, visits/s = 148.22 nnEvals/s = 135.44 nnBatches/s = 65.39 avgBatchSize = 2.07 (40.7 secs) (EloDiff +255)
    numSearchThreads =  6: 10 / 10 positions, visits/s = 228.18 nnEvals/s = 211.24 nnBatches/s = 65.02 avgBatchSize = 3.25 (26.5 secs) (EloDiff +394)
    numSearchThreads =  8: 10 / 10 positions, visits/s = 278.17 nnEvals/s = 257.59 nnBatches/s = 64.66 avgBatchSize = 3.98 (21.8 secs) (EloDiff +450)
    numSearchThreads = 12: 10 / 10 positions, visits/s = 325.44 nnEvals/s = 298.55 nnBatches/s = 50.33 avgBatchSize = 5.93 (18.8 secs) (EloDiff +474)
    numSearchThreads = 16: 10 / 10 positions, visits/s = 416.81 nnEvals/s = 391.87 nnBatches/s = 49.48 avgBatchSize = 7.92 (14.8 secs) (EloDiff +532)
    numSearchThreads = 20: 10 / 10 positions, visits/s = 504.38 nnEvals/s = 472.44 nnBatches/s = 48.08 avgBatchSize = 9.83 (12.3 secs) (EloDiff +568)
    numSearchThreads = 24: 10 / 10 positions, visits/s = 476.80 nnEvals/s = 451.77 nnBatches/s = 38.42 avgBatchSize = 11.76 (13.1 secs) (EloDiff +516)
    numSearchThreads = 28: 10 / 10 positions, visits/s = 516.76 nnEvals/s = 489.98 nnBatches/s = 36.10 avgBatchSize = 13.57 (12.1 secs) (EloDiff +513)
    numSearchThreads = 32: 10 / 10 positions, visits/s = 533.50 nnEvals/s = 510.24 nnBatches/s = 32.21 avgBatchSize = 15.84 (11.8 secs) (EloDiff +493)
    
    Based on some test data, each thread costs perhaps ~8 Elo holding visits fixed (by making MCTS worse).
    Based on some test data, each speed doubling gains perhaps ~250 Elo by searching deeper.
    So APPROXIMATELY based on this benchmark: 
    numSearchThreads =  1: (baseline)
    numSearchThreads =  2:   +23 Elo
    numSearchThreads =  4:  +255 Elo
    numSearchThreads =  6:  +394 Elo
    numSearchThreads =  8:  +450 Elo
    numSearchThreads = 12:  +474 Elo
    numSearchThreads = 16:  +532 Elo
    numSearchThreads = 20:  +568 Elo
    numSearchThreads = 24:  +516 Elo
    numSearchThreads = 28:  +513 Elo
    numSearchThreads = 32:  +493 Elo


