### PR TITLE
Better benchmarking with ternary search + adjusting time/move

### DIFF
--- a/cpp/benchmark.cpp
+++ b/cpp/benchmark.cpp
@@ -354,17 +354,12 @@ int MainCmds::benchmark(int argc, const char* const* argv) {
                 << " avgBatchSize = " << Global::strprintf("%.2f",avgBatchSize)
                 << " (" << Global::strprintf("%.1f", totalSeconds) << " secs)";
 
-    cout << "\rnumSearchThreads = " << Global::strprintf("%2d",numThreads) << ":"
-         << " " << totalPositions << " / " << possiblePositionIdxs.size() << " positions,"
-         << " visits/s = " << Global::strprintf("%.2f",totalVisits / totalSeconds)
-         << " nnEvals/s = " << Global::strprintf("%.2f",numNNEvals / totalSeconds)
-         << " nnBatches/s = " << Global::strprintf("%.2f",numNNBatches / totalSeconds)
-         << " avgBatchSize = " << Global::strprintf("%.2f",avgBatchSize)
-         << " (" << Global::strprintf("%.1f", totalSeconds) << " secs)";
+    string outputString = outputStream.str();
+    cout << outputString;
     
     cout << std::flush;
 
-    return make_pair(eloEffect, outputStream.str());
+    return make_pair(eloEffect, outputString);
   };
 
   auto printResults = [&](vector<double> eloEffects, int bestEloEffectIdx) {

--- a/cpp/benchmark.cpp
+++ b/cpp/benchmark.cpp
@@ -504,7 +504,7 @@ int MainCmds::benchmark(int argc, const char* const* argv) {
 
       if(3 * bestThreads > 2 * ternarySearchMax) {
         ternarySearchMax *= 2;
-        cout << endl << "Optimal number of threads is fairly high, doubling the search limit and trying again." << endl;
+        cout << endl << endl << "Optimal number of threads is fairly high, doubling the search limit and trying again." << endl;
       } else {
         stopped = true;
 

--- a/cpp/benchmark.cpp
+++ b/cpp/benchmark.cpp
@@ -451,6 +451,7 @@ int MainCmds::benchmark(int argc, const char* const* argv) {
       }
     }
 
+    cout << endl;
     printResults(eloEffects, bestEloEffectIdx);
   }
   


### PR DESCRIPTION
Add a ternary search feature (through `-s` flag) that allows us to optimize between large thread ranges with significantly reduced computation. This will allow for much easier and quicker benchmarking on extremely powerful hardware. Control the maximum number of threads to search up to with `-m`. The higher the maximum, the more beneficial ternary search will be. 

(It's important to note that the ternary search will never be perfect, since the function of threads to strength isn't completely convex and has some noise built in. However, the estimate is fairly close to the maximum strength option. For small thread counts and moderate strength hardware, just testing manually with `-t` is probably good enough.)

The ternary search feature is also beneficial in that it provides a way to search for a good thread count and not just have the user tell the program to try a boatload of options.

Also added a time per move feature `-i` that should allow for more accurate strength estimates given a certain number of seconds per move of thinking time (this utilizes the existing formula). 

Here are some examples of outputs with these flags (irrelevant outputs omitted):
https://gist.github.com/farmersrice/f3a327945a4f95ac1ef595552e995f30