### PR TITLE
[WIP] Standardize network argument and allow default paths if available

### DIFF
--- a/cpp/analysis.cpp
+++ b/cpp/analysis.cpp
@@ -38,13 +38,12 @@ int MainCmds::analysis(int argc, const char* const* argv) {
   int numAnalysisThreads;
   try {
     KataGoCommandLine cmd("Run parallel analysis engine");
-    TCLAP::ValueArg<string> configFileArg("","config","Config file to use (see configs/gtp_example.cfg)",true,string(),"FILE");
+    cmd.addConfigFileArg();
     cmd.addModelFileArg();
     TCLAP::ValueArg<int> numAnalysisThreadsArg("","analysis-threads","Analysis up to this many positions in parallel",true,0,"THREADS");
-    cmd.add(configFileArg);
     cmd.add(numAnalysisThreadsArg);
     cmd.parse(argc,argv);
-    configFile = configFileArg.getValue();
+    configFile = cmd.configFileArg.getValue();
     modelFile = cmd.modelFileArg.getValue();
     numAnalysisThreads = numAnalysisThreadsArg.getValue();
 

--- a/cpp/analysis.cpp
+++ b/cpp/analysis.cpp
@@ -5,10 +5,8 @@
 #include "program/setup.h"
 #include "program/playutils.h"
 #include "program/play.h"
+#include "commandline.h"
 #include "main.h"
-
-#define TCLAP_NAMESTARTSTRING "-" //Use single dashes for all flags
-#include <tclap/CmdLine.h>
 
 #include "external/nlohmann_json/json.hpp"
 

--- a/cpp/analysis.cpp
+++ b/cpp/analysis.cpp
@@ -37,16 +37,14 @@ int MainCmds::analysis(int argc, const char* const* argv) {
   string modelFile;
   int numAnalysisThreads;
   try {
-    TCLAP::CmdLine cmd("Run parallel analysis engine", ' ', Version::getKataGoVersionForHelp(),true);
+    KataGoCommandLine cmd("Run parallel analysis engine");
     TCLAP::ValueArg<string> configFileArg("","config","Config file to use (see configs/gtp_example.cfg)",true,string(),"FILE");
-    TCLAP::ValueArg<string> modelFileArg("","model","Neural net model file",true,string(),"FILE");
     TCLAP::ValueArg<int> numAnalysisThreadsArg("","analysis-threads","Analysis up to this many positions in parallel",true,0,"THREADS");
     cmd.add(configFileArg);
-    cmd.add(modelFileArg);
     cmd.add(numAnalysisThreadsArg);
     cmd.parse(argc,argv);
     configFile = configFileArg.getValue();
-    modelFile = modelFileArg.getValue();
+    modelFile = cmd.modelFileArg.getValue();
     numAnalysisThreads = numAnalysisThreadsArg.getValue();
 
     if(numAnalysisThreads <= 0 || numAnalysisThreads >= 16384)

--- a/cpp/analysis.cpp
+++ b/cpp/analysis.cpp
@@ -39,6 +39,7 @@ int MainCmds::analysis(int argc, const char* const* argv) {
   try {
     KataGoCommandLine cmd("Run parallel analysis engine");
     TCLAP::ValueArg<string> configFileArg("","config","Config file to use (see configs/gtp_example.cfg)",true,string(),"FILE");
+    cmd.addModelFileArg();
     TCLAP::ValueArg<int> numAnalysisThreadsArg("","analysis-threads","Analysis up to this many positions in parallel",true,0,"THREADS");
     cmd.add(configFileArg);
     cmd.add(numAnalysisThreadsArg);

--- a/cpp/benchmark.cpp
+++ b/cpp/benchmark.cpp
@@ -62,9 +62,8 @@ int MainCmds::benchmark(int argc, const char* const* argv) {
   bool autoTuneThreads;
   int secondsPerGameMove;
   try {
-    TCLAP::CmdLine cmd("Benchmark to test speed with different numbers of threads", ' ', Version::getKataGoVersionForHelp(),true);
+    KataGoCommandLine cmd("Benchmark to test speed with different numbers of threads");
     TCLAP::ValueArg<string> configFileArg("","config","Config file to use, same as for gtp (see gtp_example.cfg)",true,string(),"FILE");
-    TCLAP::ValueArg<string> modelFileArg("","model","Neural net model file to use",true,string(),"FILE");
     TCLAP::ValueArg<string> sgfFileArg("","sgf", "Optional game to sample positions from (default: uses a built-in-set of positions)",false,string(),"FILE");
     TCLAP::ValueArg<int> boardSizeArg("","boardsize", "Size of board to benchmark on (9-19), default 19",false,-1,"SIZE");
     TCLAP::ValueArg<long> visitsArg("v","visits","How many visits to use per search (default " + Global::int64ToString(defaultMaxVisits) + ")",false,(long)defaultMaxVisits,"VISITS");
@@ -75,7 +74,6 @@ int MainCmds::benchmark(int argc, const char* const* argv) {
                                                Global::doubleToString(defaultSecondsPerGameMove) + ")",false,defaultSecondsPerGameMove,"SECONDS");
 
     cmd.add(configFileArg);
-    cmd.add(modelFileArg);
     cmd.add(sgfFileArg);
     cmd.add(boardSizeArg);
     cmd.add(visitsArg);
@@ -86,7 +84,7 @@ int MainCmds::benchmark(int argc, const char* const* argv) {
     cmd.parse(argc,argv);
 
     configFile = configFileArg.getValue();
-    modelFile = modelFileArg.getValue();
+    modelFile = cmd.modelFileArg.getValue();
     sgfFile = sgfFileArg.getValue();
     boardSize = boardSizeArg.getValue();
     maxVisits = (int64_t)visitsArg.getValue();
@@ -435,16 +433,14 @@ int MainCmds::genconfig(int argc, const char* const* argv, const char* firstComm
   string outputFile;
   string modelFile;
   try {
-    TCLAP::CmdLine cmd("Automatically generate and tune a new GTP config", ' ', Version::getKataGoVersionForHelp(),true);
+    KataGoCommandLine cmd("Automatically generate and tune a new GTP config");
     TCLAP::ValueArg<string> outputFileArg("","output","Path to write new config (default gtp.cfg)",false,string("gtp.cfg"),"FILE");
-    TCLAP::ValueArg<string> modelFileArg("","model","Neural net model file to use",true,string(),"FILE");
 
     cmd.add(outputFileArg);
-    cmd.add(modelFileArg);
     cmd.parse(argc,argv);
 
     outputFile = outputFileArg.getValue();
-    modelFile = modelFileArg.getValue();
+    modelFile = cmd.modelFileArg.getValue();
   }
   catch (TCLAP::ArgException &e) {
     cerr << "Error: " << e.error() << " for argument " << e.argId() << endl;

--- a/cpp/benchmark.cpp
+++ b/cpp/benchmark.cpp
@@ -7,6 +7,7 @@
 #include "program/playutils.h"
 #include "program/gtpconfig.h"
 #include "tests/tests.h"
+#include "commandline.h"
 #include "main.h"
 
 #include <chrono>
@@ -16,9 +17,6 @@
 
 #include <boost/filesystem.hpp>
 namespace bfs = boost::filesystem;
-
-#define TCLAP_NAMESTARTSTRING "-" //Use single dashes for all flags
-#include <tclap/CmdLine.h>
 
 using namespace std;
 

--- a/cpp/benchmark.cpp
+++ b/cpp/benchmark.cpp
@@ -64,6 +64,7 @@ int MainCmds::benchmark(int argc, const char* const* argv) {
   try {
     KataGoCommandLine cmd("Benchmark to test speed with different numbers of threads");
     TCLAP::ValueArg<string> configFileArg("","config","Config file to use, same as for gtp (see gtp_example.cfg)",true,string(),"FILE");
+    cmd.addModelFileArg();
     TCLAP::ValueArg<string> sgfFileArg("","sgf", "Optional game to sample positions from (default: uses a built-in-set of positions)",false,string(),"FILE");
     TCLAP::ValueArg<int> boardSizeArg("","boardsize", "Size of board to benchmark on (9-19), default 19",false,-1,"SIZE");
     TCLAP::ValueArg<long> visitsArg("v","visits","How many visits to use per search (default " + Global::int64ToString(defaultMaxVisits) + ")",false,(long)defaultMaxVisits,"VISITS");
@@ -434,6 +435,7 @@ int MainCmds::genconfig(int argc, const char* const* argv, const char* firstComm
   string modelFile;
   try {
     KataGoCommandLine cmd("Automatically generate and tune a new GTP config");
+    cmd.addModelFileArg();
     TCLAP::ValueArg<string> outputFileArg("","output","Path to write new config (default gtp.cfg)",false,string("gtp.cfg"),"FILE");
 
     cmd.add(outputFileArg);

--- a/cpp/benchmark.cpp
+++ b/cpp/benchmark.cpp
@@ -63,7 +63,7 @@ int MainCmds::benchmark(int argc, const char* const* argv) {
   int secondsPerGameMove;
   try {
     KataGoCommandLine cmd("Benchmark to test speed with different numbers of threads");
-    TCLAP::ValueArg<string> configFileArg("","config","Config file to use, same as for gtp (see gtp_example.cfg)",true,string(),"FILE");
+    cmd.addConfigFileArg();
     cmd.addModelFileArg();
     TCLAP::ValueArg<string> sgfFileArg("","sgf", "Optional game to sample positions from (default: uses a built-in-set of positions)",false,string(),"FILE");
     TCLAP::ValueArg<int> boardSizeArg("","boardsize", "Size of board to benchmark on (9-19), default 19",false,-1,"SIZE");
@@ -74,7 +74,6 @@ int MainCmds::benchmark(int argc, const char* const* argv) {
     TCLAP::ValueArg<int> secondsPerGameMoveArg("i","time","Typical amount of time per move spent while playing, in seconds (default " +
                                                Global::doubleToString(defaultSecondsPerGameMove) + ")",false,defaultSecondsPerGameMove,"SECONDS");
 
-    cmd.add(configFileArg);
     cmd.add(sgfFileArg);
     cmd.add(boardSizeArg);
     cmd.add(visitsArg);
@@ -84,7 +83,7 @@ int MainCmds::benchmark(int argc, const char* const* argv) {
     cmd.add(secondsPerGameMoveArg);
     cmd.parse(argc,argv);
 
-    configFile = configFileArg.getValue();
+    configFile = cmd.configFileArg.getValue();
     modelFile = cmd.modelFileArg.getValue();
     sgfFile = sgfFileArg.getValue();
     boardSize = boardSizeArg.getValue();

--- a/cpp/commandline.h
+++ b/cpp/commandline.h
@@ -1,0 +1,71 @@
+#include "main.h"
+#include "core/os.h"
+
+// REFACT this could be the central location to include tclap and define this convention
+// as this is extra define is currently replicated all over the source
+#define TCLAP_NAMESTARTSTRING "-" //Use single dashes for all flags
+#include <tclap/CmdLine.h>
+
+#if defined(OS_IS_UNIX_OR_APPLE)
+    #include <wordexp.h>
+#elif defined(OS_IS_WINDOWS)
+    // TODO whatever windows needs to expand the path to the home directory
+#else
+    #error Unknown operating system!
+#endif
+
+#include <boost/filesystem.hpp>
+namespace bfs = boost::filesystem;
+
+
+using namespace std;
+
+class KataGoCommandLine : public TCLAP::CmdLine
+{
+public:
+    TCLAP::ValueArg<string> nnModelFileArg;
+    
+    KataGoCommandLine(const std::string& message)
+        :
+            TCLAP::CmdLine(message, ' ', Version::getKataGoVersionForHelp(),true),
+            nnModelFileArg("","model","Neural net model file", !hasDefaultModelPath(), defaultModelPath(),"FILE")
+    {
+        this->add(this->nnModelFileArg);
+    }
+    
+    static std::string defaultModelPath() {
+        // TODO search for a network configured by symlink in ~/.katago/default_network.txt.gz
+        // and provide that as the default value if available.
+        
+        bfs::path homeDirectory = getHomeDirectory();
+        bfs::path standardModelPath = homeDirectory / ".config/katago/standard_model.txt.gz";
+        // cout << standard_model_location << endl;
+        if ( bfs::exists(standardModelPath)) {
+            return standardModelPath.native();
+        }
+        
+        // no default network found
+        return std::string();
+    }
+    
+    static bool hasDefaultModelPath() {
+        return ! defaultModelPath().empty();
+    }
+    
+    static bfs::path getHomeDirectory() {
+        bfs::path homeDirectory;
+#if defined(OS_IS_WINDOWS)
+        #error FIXME needs implementing
+        // TODO I have no clue how windows handles this
+        // possibly using ExpandEnvironmentString, see https://stackoverflow.com/questions/1902681/expand-file-names-that-have-environment-variables-in-their-path
+#elif defined(OS_IS_UNIX_OR_APPLE)
+        wordexp_t expandedPath;
+        wordexp("~", &expandedPath, 0);
+        homeDirectory = expandedPath.we_wordv[0];
+        wordfree(&expandedPath);
+#else
+        #error Unknown operating system!
+#endif
+        return homeDirectory;
+    }
+};

--- a/cpp/commandline.h
+++ b/cpp/commandline.h
@@ -29,37 +29,43 @@ public:
     KataGoCommandLine(const std::string& message)
         :
             TCLAP::CmdLine(message, ' ', Version::getKataGoVersionForHelp(),true),
-            modelFileArg("","model","Neural net model file", !hasDefaultModelPath(), defaultModelPath(),"FILE"),
-            configFileArg("","config","Config file to use (see configs/*_example.cfg)",true,string(),"FILE")
+            modelFileArg("","model","Neural net model file. Defaults to: " + defaultModelPath(), 
+                !hasDefaultModelPath(), defaultModelPath(),"FILE"),
+            configFileArg("","config","Config file to use (see configs/*_example.cfg). Defaults to: " + defaultConfigPath(), 
+                !hasDefaultConfigPath(),defaultConfigPath(),"FILE")
     {
     }
+    
+#pragma mark modelFileArg
     
     void addModelFileArg() {
         this->add(this->modelFileArg);
     }
     
-    void addConfigFileArg() {
-        this->add(this->configFileArg);
-    }
-    
     static std::string defaultModelPath() {
-        // TODO search for a network configured by symlink in ~/.katago/default_network.txt.gz
-        // and provide that as the default value if available.
-        
-        bfs::path homeDirectory = getHomeDirectory();
-        bfs::path standardModelPath = homeDirectory / ".config/katago/standard_model.txt.gz";
-        // cout << standard_model_location << endl;
-        if ( bfs::exists(standardModelPath)) {
-            return standardModelPath.native();
-        }
-        
-        // no default network found
-        return std::string();
+        return defaultPathIfItExists("default_model.bin.gz");
     }
     
     static bool hasDefaultModelPath() {
         return ! defaultModelPath().empty();
     }
+    
+#pragma mark configFileArg
+    
+    void addConfigFileArg() {
+        this->add(this->configFileArg);
+    }
+    
+    static std::string defaultConfigPath() {
+        return defaultPathIfItExists("default_config.cfg");
+    }
+    
+    static bool hasDefaultConfigPath() {
+        return ! defaultModelPath().empty();
+    }
+    
+    
+#pragma mark Support code
     
     static bfs::path getHomeDirectory() {
         bfs::path homeDirectory;
@@ -76,5 +82,16 @@ public:
         #error Unknown operating system!
 #endif
         return homeDirectory;
+    }
+    
+    static std::string defaultPathIfItExists(bfs::path standardFileName) {
+        bfs::path homeDirectory = getHomeDirectory();
+        bfs::path standardModelPath = homeDirectory / ".katago" / standardFileName;
+        if ( bfs::exists(standardModelPath)) {
+            return standardModelPath.native();
+        }
+        
+        // no default file found
+        return std::string();
     }
 };

--- a/cpp/commandline.h
+++ b/cpp/commandline.h
@@ -30,6 +30,9 @@ public:
             TCLAP::CmdLine(message, ' ', Version::getKataGoVersionForHelp(),true),
             modelFileArg("","model","Neural net model file", !hasDefaultModelPath(), defaultModelPath(),"FILE")
     {
+    }
+    
+    void addModelFileArg() {
         this->add(this->modelFileArg);
     }
     

--- a/cpp/commandline.h
+++ b/cpp/commandline.h
@@ -24,16 +24,22 @@ class KataGoCommandLine : public TCLAP::CmdLine
 {
 public:
     TCLAP::ValueArg<string> modelFileArg;
+    TCLAP::ValueArg<string> configFileArg;
     
     KataGoCommandLine(const std::string& message)
         :
             TCLAP::CmdLine(message, ' ', Version::getKataGoVersionForHelp(),true),
-            modelFileArg("","model","Neural net model file", !hasDefaultModelPath(), defaultModelPath(),"FILE")
+            modelFileArg("","model","Neural net model file", !hasDefaultModelPath(), defaultModelPath(),"FILE"),
+            configFileArg("","config","Config file to use (see configs/*_example.cfg)",true,string(),"FILE")
     {
     }
     
     void addModelFileArg() {
         this->add(this->modelFileArg);
+    }
+    
+    void addConfigFileArg() {
+        this->add(this->configFileArg);
     }
     
     static std::string defaultModelPath() {

--- a/cpp/commandline.h
+++ b/cpp/commandline.h
@@ -23,14 +23,14 @@ using namespace std;
 class KataGoCommandLine : public TCLAP::CmdLine
 {
 public:
-    TCLAP::ValueArg<string> nnModelFileArg;
+    TCLAP::ValueArg<string> modelFileArg;
     
     KataGoCommandLine(const std::string& message)
         :
             TCLAP::CmdLine(message, ' ', Version::getKataGoVersionForHelp(),true),
-            nnModelFileArg("","model","Neural net model file", !hasDefaultModelPath(), defaultModelPath(),"FILE")
+            modelFileArg("","model","Neural net model file", !hasDefaultModelPath(), defaultModelPath(),"FILE")
     {
-        this->add(this->nnModelFileArg);
+        this->add(this->modelFileArg);
     }
     
     static std::string defaultModelPath() {

--- a/cpp/evalsgf.cpp
+++ b/cpp/evalsgf.cpp
@@ -33,9 +33,8 @@ int MainCmds::evalsgf(int argc, const char* const* argv) {
   bool printLead;
   bool rawNN;
   try {
-    TCLAP::CmdLine cmd("Run a search on a position from an sgf file", ' ', Version::getKataGoVersionForHelp(),true);
+    KataGoCommandLine cmd("Run a search on a position from an sgf file");
     TCLAP::ValueArg<string> configFileArg("","config","Config file to use (see configs/gtp_example.cfg)",true,string(),"FILE");
-    TCLAP::ValueArg<string> modelFileArg("","model","Neural net model file to use",true,string(),"FILE");
     TCLAP::UnlabeledValueArg<string> sgfFileArg("","Sgf file to analyze",true,string(),"FILE");
     TCLAP::ValueArg<int> moveNumArg("m","move-num","Sgf move num to analyze, 1-indexed",true,0,"MOVENUM");
     TCLAP::ValueArg<string> printBranchArg("","print-branch","Move branch in search tree to print",false,string(),"MOVE MOVE ...");
@@ -53,7 +52,6 @@ int MainCmds::evalsgf(int argc, const char* const* argv) {
     TCLAP::SwitchArg printLeadArg("","print-lead","Compute and print lead");
     TCLAP::SwitchArg rawNNArg("","raw-nn","Perform single raw neural net eval");
     cmd.add(configFileArg);
-    cmd.add(modelFileArg);
     cmd.add(sgfFileArg);
     cmd.add(moveNumArg);
     cmd.add(printBranchArg);
@@ -72,7 +70,7 @@ int MainCmds::evalsgf(int argc, const char* const* argv) {
     cmd.add(rawNNArg);
     cmd.parse(argc,argv);
     configFile = configFileArg.getValue();
-    modelFile = modelFileArg.getValue();
+    modelFile = cmd.modelFileArg.getValue();
     sgfFile = sgfFileArg.getValue();
     moveNum = moveNumArg.getValue();
     printBranch = printBranchArg.getValue();

--- a/cpp/evalsgf.cpp
+++ b/cpp/evalsgf.cpp
@@ -34,7 +34,7 @@ int MainCmds::evalsgf(int argc, const char* const* argv) {
   bool rawNN;
   try {
     KataGoCommandLine cmd("Run a search on a position from an sgf file");
-    TCLAP::ValueArg<string> configFileArg("","config","Config file to use (see configs/gtp_example.cfg)",true,string(),"FILE");
+    cmd.addConfigFileArg();
     cmd.addModelFileArg();
     TCLAP::UnlabeledValueArg<string> sgfFileArg("","Sgf file to analyze",true,string(),"FILE");
     TCLAP::ValueArg<int> moveNumArg("m","move-num","Sgf move num to analyze, 1-indexed",true,0,"MOVENUM");
@@ -52,7 +52,6 @@ int MainCmds::evalsgf(int argc, const char* const* argv) {
     TCLAP::SwitchArg printRootEndingBonusArg("","print-root-ending-bonus","Print root ending bonus now");
     TCLAP::SwitchArg printLeadArg("","print-lead","Compute and print lead");
     TCLAP::SwitchArg rawNNArg("","raw-nn","Perform single raw neural net eval");
-    cmd.add(configFileArg);
     cmd.add(sgfFileArg);
     cmd.add(moveNumArg);
     cmd.add(printBranchArg);
@@ -70,7 +69,7 @@ int MainCmds::evalsgf(int argc, const char* const* argv) {
     cmd.add(printLeadArg);
     cmd.add(rawNNArg);
     cmd.parse(argc,argv);
-    configFile = configFileArg.getValue();
+    configFile = cmd.configFileArg.getValue();
     modelFile = cmd.modelFileArg.getValue();
     sgfFile = sgfFileArg.getValue();
     moveNum = moveNumArg.getValue();

--- a/cpp/evalsgf.cpp
+++ b/cpp/evalsgf.cpp
@@ -35,6 +35,7 @@ int MainCmds::evalsgf(int argc, const char* const* argv) {
   try {
     KataGoCommandLine cmd("Run a search on a position from an sgf file");
     TCLAP::ValueArg<string> configFileArg("","config","Config file to use (see configs/gtp_example.cfg)",true,string(),"FILE");
+    cmd.addModelFileArg();
     TCLAP::UnlabeledValueArg<string> sgfFileArg("","Sgf file to analyze",true,string(),"FILE");
     TCLAP::ValueArg<int> moveNumArg("m","move-num","Sgf move num to analyze, 1-indexed",true,0,"MOVENUM");
     TCLAP::ValueArg<string> printBranchArg("","print-branch","Move branch in search tree to print",false,string(),"MOVE MOVE ...");

--- a/cpp/evalsgf.cpp
+++ b/cpp/evalsgf.cpp
@@ -6,10 +6,8 @@
 #include "program/setup.h"
 #include "program/playutils.h"
 #include "program/play.h"
+#include "commandline.h"
 #include "main.h"
-
-#define TCLAP_NAMESTARTSTRING "-" //Use single dashes for all flags
-#include <tclap/CmdLine.h>
 
 using namespace std;
 

--- a/cpp/gatekeeper.cpp
+++ b/cpp/gatekeeper.cpp
@@ -10,12 +10,10 @@
 #include "search/asyncbot.h"
 #include "program/setup.h"
 #include "program/play.h"
+#include "commandline.h"
 #include "main.h"
 
 #include <sstream>
-
-#define TCLAP_NAMESTARTSTRING "-" //Use single dashes for all flags
-#include <tclap/CmdLine.h>
 
 #include <cstdio>
 #include <chrono>

--- a/cpp/gatekeeper.cpp
+++ b/cpp/gatekeeper.cpp
@@ -217,7 +217,7 @@ int MainCmds::gatekeeper(int argc, const char* const* argv) {
   bool noAutoRejectOldModels;
   bool quitIfNoNetsToTest;
   try {
-    TCLAP::CmdLine cmd("Test neural nets to see if they should be accepted", ' ', Version::getKataGoVersionForHelp(),true);
+    KataGoCommandLine cmd("Test neural nets to see if they should be accepted");
     TCLAP::ValueArg<string> configFileArg("","config-file","Config file to use",true,string(),"FILE");
     TCLAP::ValueArg<string> testModelsDirArg("","test-models-dir","Dir to poll and load models from",true,string(),"DIR");
     TCLAP::ValueArg<string> sgfOutputDirArg("","sgf-output-dir","Dir to output sgf files",true,string(),"DIR");

--- a/cpp/gatekeeper.cpp
+++ b/cpp/gatekeeper.cpp
@@ -218,14 +218,13 @@ int MainCmds::gatekeeper(int argc, const char* const* argv) {
   bool quitIfNoNetsToTest;
   try {
     KataGoCommandLine cmd("Test neural nets to see if they should be accepted");
-    TCLAP::ValueArg<string> configFileArg("","config-file","Config file to use",true,string(),"FILE");
+    cmd.addConfigFileArg();
     TCLAP::ValueArg<string> testModelsDirArg("","test-models-dir","Dir to poll and load models from",true,string(),"DIR");
     TCLAP::ValueArg<string> sgfOutputDirArg("","sgf-output-dir","Dir to output sgf files",true,string(),"DIR");
     TCLAP::ValueArg<string> acceptedModelsDirArg("","accepted-models-dir","Dir to write good models to",true,string(),"DIR");
     TCLAP::ValueArg<string> rejectedModelsDirArg("","rejected-models-dir","Dir to write bad models to",true,string(),"DIR");
     TCLAP::SwitchArg noAutoRejectOldModelsArg("","no-autoreject-old-models","Test older models than the latest accepted model");
     TCLAP::SwitchArg quitIfNoNetsToTestArg("","quit-if-no-nets-to-test","Terminate instead of waiting for a new net to test");
-    cmd.add(configFileArg);
     cmd.add(testModelsDirArg);
     cmd.add(sgfOutputDirArg);
     cmd.add(acceptedModelsDirArg);
@@ -233,7 +232,7 @@ int MainCmds::gatekeeper(int argc, const char* const* argv) {
     cmd.add(noAutoRejectOldModelsArg);
     cmd.add(quitIfNoNetsToTestArg);
     cmd.parse(argc,argv);
-    configFile = configFileArg.getValue();
+    configFile = cmd.configFileArg.getValue();
     testModelsDir = testModelsDirArg.getValue();
     sgfOutputDir = sgfOutputDirArg.getValue();
     acceptedModelsDir = acceptedModelsDirArg.getValue();

--- a/cpp/gtp.cpp
+++ b/cpp/gtp.cpp
@@ -1181,6 +1181,7 @@ int MainCmds::gtp(int argc, const char* const* argv) {
   try {
     KataGoCommandLine cmd("Run GTP engine");
     TCLAP::ValueArg<string> configFileArg("","config","Config file to use (see configs/gtp_example.cfg)",true,string(),"FILE");
+    cmd.addModelFileArg();
     TCLAP::ValueArg<string> overrideVersionArg("","override-version","Force KataGo to say a certain value in response to gtp version command",false,string(),"VERSION");
     TCLAP::ValueArg<string> overrideConfigArg("","override-config","Override config parameters. Format: \"key=value, key=value,...\"",false,string(),"KEYVALUEPAIRS");
     cmd.add(configFileArg);

--- a/cpp/gtp.cpp
+++ b/cpp/gtp.cpp
@@ -9,9 +9,6 @@
 #include "commandline.h"
 #include "main.h"
 
-#define TCLAP_NAMESTARTSTRING "-" //Use single dashes for all flags
-#include <tclap/CmdLine.h>
-
 using namespace std;
 
 static const vector<string> knownCommands = {

--- a/cpp/gtp.cpp
+++ b/cpp/gtp.cpp
@@ -1180,15 +1180,14 @@ int MainCmds::gtp(int argc, const char* const* argv) {
   string overrideConfig;
   try {
     KataGoCommandLine cmd("Run GTP engine");
-    TCLAP::ValueArg<string> configFileArg("","config","Config file to use (see configs/gtp_example.cfg)",true,string(),"FILE");
+    cmd.addConfigFileArg();
     cmd.addModelFileArg();
     TCLAP::ValueArg<string> overrideVersionArg("","override-version","Force KataGo to say a certain value in response to gtp version command",false,string(),"VERSION");
     TCLAP::ValueArg<string> overrideConfigArg("","override-config","Override config parameters. Format: \"key=value, key=value,...\"",false,string(),"KEYVALUEPAIRS");
-    cmd.add(configFileArg);
     cmd.add(overrideVersionArg);
     cmd.add(overrideConfigArg);
     cmd.parse(argc,argv);
-    configFile = configFileArg.getValue();
+    configFile = cmd.configFileArg.getValue();
     nnModelFile = cmd.modelFileArg.getValue();
     overrideVersion = overrideVersionArg.getValue();
     overrideConfig = overrideConfigArg.getValue();

--- a/cpp/gtp.cpp
+++ b/cpp/gtp.cpp
@@ -1171,6 +1171,26 @@ static GTPEngine::AnalyzeArgs parseAnalyzeCommand(const string& command, const v
 }
 
 
+class KataGoCommandLine : public TCLAP::CmdLine
+{
+public:
+    TCLAP::ValueArg<string> nnModelFileArg;
+    
+    KataGoCommandLine(const std::string& message)
+        :
+            TCLAP::CmdLine(message, ' ', Version::getKataGoVersionForHelp(),true),
+            nnModelFileArg("","model","Neural net model file",true, defaultNNModelPath(),"FILE")
+    {
+        this->add(this->nnModelFileArg);
+    }
+    
+    static string defaultNNModelPath() {
+        // TODO search for a network configured by symlink in ~/.katago/default_network.txt.gz
+        // and provide that as. the default value if available.
+        return string();
+    }
+};
+
 int MainCmds::gtp(int argc, const char* const* argv) {
   Board::initHash();
   ScoreValue::initTables();
@@ -1181,18 +1201,16 @@ int MainCmds::gtp(int argc, const char* const* argv) {
   string overrideVersion;
   string overrideConfig;
   try {
-    TCLAP::CmdLine cmd("Run GTP engine", ' ', Version::getKataGoVersionForHelp(),true);
+    KataGoCommandLine cmd("Run GTP engine");
     TCLAP::ValueArg<string> configFileArg("","config","Config file to use (see configs/gtp_example.cfg)",true,string(),"FILE");
-    TCLAP::ValueArg<string> nnModelFileArg("","model","Neural net model file",true,string(),"FILE");
     TCLAP::ValueArg<string> overrideVersionArg("","override-version","Force KataGo to say a certain value in response to gtp version command",false,string(),"VERSION");
     TCLAP::ValueArg<string> overrideConfigArg("","override-config","Override config parameters. Format: \"key=value, key=value,...\"",false,string(),"KEYVALUEPAIRS");
     cmd.add(configFileArg);
-    cmd.add(nnModelFileArg);
     cmd.add(overrideVersionArg);
     cmd.add(overrideConfigArg);
     cmd.parse(argc,argv);
     configFile = configFileArg.getValue();
-    nnModelFile = nnModelFileArg.getValue();
+    nnModelFile = cmd.nnModelFileArg.getValue();
     overrideVersion = overrideVersionArg.getValue();
     overrideConfig = overrideConfigArg.getValue();
   }

--- a/cpp/gtp.cpp
+++ b/cpp/gtp.cpp
@@ -1191,7 +1191,7 @@ int MainCmds::gtp(int argc, const char* const* argv) {
     cmd.add(overrideConfigArg);
     cmd.parse(argc,argv);
     configFile = configFileArg.getValue();
-    nnModelFile = cmd.nnModelFileArg.getValue();
+    nnModelFile = cmd.modelFileArg.getValue();
     overrideVersion = overrideVersionArg.getValue();
     overrideConfig = overrideConfigArg.getValue();
   }

--- a/cpp/gtp.cpp
+++ b/cpp/gtp.cpp
@@ -1186,7 +1186,7 @@ public:
     
     static string defaultNNModelPath() {
         // TODO search for a network configured by symlink in ~/.katago/default_network.txt.gz
-        // and provide that as. the default value if available.
+        // and provide that as the default value if available.
         return string();
     }
 };

--- a/cpp/gtp.cpp
+++ b/cpp/gtp.cpp
@@ -6,6 +6,7 @@
 #include "program/setup.h"
 #include "program/playutils.h"
 #include "program/play.h"
+#include "commandline.h"
 #include "main.h"
 
 #define TCLAP_NAMESTARTSTRING "-" //Use single dashes for all flags
@@ -1170,26 +1171,6 @@ static GTPEngine::AnalyzeArgs parseAnalyzeCommand(const string& command, const v
   return args;
 }
 
-
-class KataGoCommandLine : public TCLAP::CmdLine
-{
-public:
-    TCLAP::ValueArg<string> nnModelFileArg;
-    
-    KataGoCommandLine(const std::string& message)
-        :
-            TCLAP::CmdLine(message, ' ', Version::getKataGoVersionForHelp(),true),
-            nnModelFileArg("","model","Neural net model file",true, defaultNNModelPath(),"FILE")
-    {
-        this->add(this->nnModelFileArg);
-    }
-    
-    static string defaultNNModelPath() {
-        // TODO search for a network configured by symlink in ~/.katago/default_network.txt.gz
-        // and provide that as the default value if available.
-        return string();
-    }
-};
 
 int MainCmds::gtp(int argc, const char* const* argv) {
   Board::initHash();

--- a/cpp/lzcost.cpp
+++ b/cpp/lzcost.cpp
@@ -2,12 +2,10 @@
 #include "game/board.h"
 #include "game/boardhistory.h"
 #include "dataio/lzparse.h"
+#include "commandline.h"
 #include "main.h"
 #include <fstream>
 #include <algorithm>
-
-#define TCLAP_NAMESTARTSTRING "-" //Use single dashes for all flags
-#include <tclap/CmdLine.h>
 
 using namespace std;
 

--- a/cpp/lzcost.cpp
+++ b/cpp/lzcost.cpp
@@ -114,7 +114,7 @@ int MainCmds::lzcost(int argc, const char* const* argv) {
   double sampleProb;
   string outFile;
   try {
-    TCLAP::CmdLine cmd("Sgf->HDF5 data writer", ' ', Version::getKataGoVersionForHelp(),true);
+    KataGoCommandLine cmd("Sgf->HDF5 data writer");
     TCLAP::MultiArg<string> lzdirArg("","lzdir","Directory of leela zero gzipped data files",false,"DIR");
     TCLAP::ValueArg<double> sampleProbArg("","sampleprob","Probability to sample a file",true,0.0,"PROB");
     TCLAP::ValueArg<string> outFileArg("","out","File to write results",true,string(),"FILE");

--- a/cpp/match.cpp
+++ b/cpp/match.cpp
@@ -30,7 +30,7 @@ int MainCmds::match(int argc, const char* const* argv) {
   string logFile;
   string sgfOutputDir;
   try {
-    TCLAP::CmdLine cmd("Play different nets against each other with different search settings", ' ', Version::getKataGoVersionForHelp(),true);
+    KataGoCommandLine cmd("Play different nets against each other with different search settings");
     TCLAP::ValueArg<string> configFileArg("","config-file","Config file to use (see configs/match_example.cfg)",true,string(),"FILE");
     TCLAP::ValueArg<string> logFileArg("","log-file","Log file to output to",true,string(),"FILE");
     TCLAP::ValueArg<string> sgfOutputDirArg("","sgf-output-dir","Dir to output sgf files",false,string(),"DIR");

--- a/cpp/match.cpp
+++ b/cpp/match.cpp
@@ -31,14 +31,13 @@ int MainCmds::match(int argc, const char* const* argv) {
   string sgfOutputDir;
   try {
     KataGoCommandLine cmd("Play different nets against each other with different search settings");
-    TCLAP::ValueArg<string> configFileArg("","config-file","Config file to use (see configs/match_example.cfg)",true,string(),"FILE");
+    cmd.addConfigFileArg();
     TCLAP::ValueArg<string> logFileArg("","log-file","Log file to output to",true,string(),"FILE");
     TCLAP::ValueArg<string> sgfOutputDirArg("","sgf-output-dir","Dir to output sgf files",false,string(),"DIR");
-    cmd.add(configFileArg);
     cmd.add(logFileArg);
     cmd.add(sgfOutputDirArg);
     cmd.parse(argc,argv);
-    configFile = configFileArg.getValue();
+    configFile = cmd.configFileArg.getValue();
     logFile = logFileArg.getValue();
     sgfOutputDir = sgfOutputDirArg.getValue();
   }

--- a/cpp/match.cpp
+++ b/cpp/match.cpp
@@ -6,10 +6,8 @@
 #include "search/asyncbot.h"
 #include "program/setup.h"
 #include "program/play.h"
+#include "commandline.h"
 #include "main.h"
-
-#define TCLAP_NAMESTARTSTRING "-" //Use single dashes for all flags
-#include <tclap/CmdLine.h>
 
 #include <csignal>
 

--- a/cpp/matchauto.cpp
+++ b/cpp/matchauto.cpp
@@ -7,12 +7,10 @@
 #include "search/asyncbot.h"
 #include "program/setup.h"
 #include "program/play.h"
+#include "commandline.h"
 #include "main.h"
 
 #include <boost/filesystem.hpp>
-
-#define TCLAP_NAMESTARTSTRING "-" //Use single dashes for all flags
-#include <tclap/CmdLine.h>
 
 #include <csignal>
 

--- a/cpp/matchauto.cpp
+++ b/cpp/matchauto.cpp
@@ -402,7 +402,7 @@ int MainCmds::matchauto(int argc, const char* const* argv) {
   string sgfOutputDir;
   string resultsDir;
   try {
-    TCLAP::CmdLine cmd("Play different nets against each other with different search settings", ' ', Version::getKataGoVersionForHelp(),true);
+    KataGoCommandLine cmd("Play different nets against each other with different search settings");
     TCLAP::ValueArg<string> configFileArg("","config-file","Config file to use (see configs/match_example.cfg)",true,string(),"FILE");
     TCLAP::ValueArg<string> logFileArg("","log-file","Log file to output to",true,string(),"FILE");
     TCLAP::ValueArg<string> sgfOutputDirArg("","sgf-output-dir","Dir to output sgf files",false,string(),"DIR");

--- a/cpp/matchauto.cpp
+++ b/cpp/matchauto.cpp
@@ -403,16 +403,15 @@ int MainCmds::matchauto(int argc, const char* const* argv) {
   string resultsDir;
   try {
     KataGoCommandLine cmd("Play different nets against each other with different search settings");
-    TCLAP::ValueArg<string> configFileArg("","config-file","Config file to use (see configs/match_example.cfg)",true,string(),"FILE");
+    cmd.addConfigFileArg();
     TCLAP::ValueArg<string> logFileArg("","log-file","Log file to output to",true,string(),"FILE");
     TCLAP::ValueArg<string> sgfOutputDirArg("","sgf-output-dir","Dir to output sgf files",false,string(),"DIR");
     TCLAP::ValueArg<string> resultsDirArg("","results-dir","Dir to read/write win loss result files",true,string(),"DIR");
-    cmd.add(configFileArg);
     cmd.add(logFileArg);
     cmd.add(sgfOutputDirArg);
     cmd.add(resultsDirArg);
     cmd.parse(argc,argv);
-    configFile = configFileArg.getValue();
+    configFile = cmd.configFileArg.getValue();
     logFile = logFileArg.getValue();
     sgfOutputDir = sgfOutputDirArg.getValue();
     resultsDir = resultsDirArg.getValue();

--- a/cpp/misc.cpp
+++ b/cpp/misc.cpp
@@ -367,16 +367,14 @@ int MainCmds::demoplay(int argc, const char* const* argv) {
   string logFile;
   string modelFile;
   try {
-    TCLAP::CmdLine cmd("Self-play demo dumping status to stdout", ' ', Version::getKataGoVersion(),true);
+    KataGoCommandLine cmd("Self-play demo dumping status to stdout");
     TCLAP::ValueArg<string> configFileArg("","config","Config file to use",true,string(),"FILE");
-    TCLAP::ValueArg<string> modelFileArg("","model","Neural net model file to use",true,string(),"FILE");
     TCLAP::ValueArg<string> logFileArg("","log-file","Log file to output to",true,string(),"FILE");
     cmd.add(configFileArg);
-    cmd.add(modelFileArg);
     cmd.add(logFileArg);
     cmd.parse(argc,argv);
     configFile = configFileArg.getValue();
-    modelFile = modelFileArg.getValue();
+    modelFile = cmd.modelFileArg.getValue();
     logFile = logFileArg.getValue();
   }
   catch (TCLAP::ArgException &e) {

--- a/cpp/misc.cpp
+++ b/cpp/misc.cpp
@@ -7,10 +7,8 @@
 #include "program/setup.h"
 #include "program/playutils.h"
 #include "program/play.h"
+#include "commandline.h"
 #include "main.h"
-
-#define TCLAP_NAMESTARTSTRING "-" //Use single dashes for all flags
-#include <tclap/CmdLine.h>
 
 using namespace std;
 

--- a/cpp/misc.cpp
+++ b/cpp/misc.cpp
@@ -368,13 +368,12 @@ int MainCmds::demoplay(int argc, const char* const* argv) {
   string modelFile;
   try {
     KataGoCommandLine cmd("Self-play demo dumping status to stdout");
-    TCLAP::ValueArg<string> configFileArg("","config","Config file to use",true,string(),"FILE");
+    cmd.addConfigFileArg();
     cmd.addModelFileArg();
     TCLAP::ValueArg<string> logFileArg("","log-file","Log file to output to",true,string(),"FILE");
-    cmd.add(configFileArg);
     cmd.add(logFileArg);
     cmd.parse(argc,argv);
-    configFile = configFileArg.getValue();
+    configFile = cmd.configFileArg.getValue();
     modelFile = cmd.modelFileArg.getValue();
     logFile = logFileArg.getValue();
   }

--- a/cpp/misc.cpp
+++ b/cpp/misc.cpp
@@ -369,6 +369,7 @@ int MainCmds::demoplay(int argc, const char* const* argv) {
   try {
     KataGoCommandLine cmd("Self-play demo dumping status to stdout");
     TCLAP::ValueArg<string> configFileArg("","config","Config file to use",true,string(),"FILE");
+    cmd.addModelFileArg();
     TCLAP::ValueArg<string> logFileArg("","log-file","Log file to output to",true,string(),"FILE");
     cmd.add(configFileArg);
     cmd.add(logFileArg);

--- a/cpp/selfplay.cpp
+++ b/cpp/selfplay.cpp
@@ -166,14 +166,13 @@ int MainCmds::selfplay(int argc, const char* const* argv) {
   string outputDir;
   try {
     KataGoCommandLine cmd("Generate training data via self play");
-    TCLAP::ValueArg<string> configFileArg("","config-file","Config file to use",true,string(),"FILE");
+    cmd.addConfigFileArg();
     TCLAP::ValueArg<string> modelsDirArg("","models-dir","Dir to poll and load models from",true,string(),"DIR");
     TCLAP::ValueArg<string> outputDirArg("","output-dir","Dir to output files",true,string(),"DIR");
-    cmd.add(configFileArg);
     cmd.add(modelsDirArg);
     cmd.add(outputDirArg);
     cmd.parse(argc,argv);
-    configFile = configFileArg.getValue();
+    configFile = cmd.configFileArg.getValue();
     modelsDir = modelsDirArg.getValue();
     outputDir = outputDirArg.getValue();
 

--- a/cpp/selfplay.cpp
+++ b/cpp/selfplay.cpp
@@ -11,10 +11,8 @@
 #include "search/asyncbot.h"
 #include "program/setup.h"
 #include "program/play.h"
+#include "commandline.h"
 #include "main.h"
-
-#define TCLAP_NAMESTARTSTRING "-" //Use single dashes for all flags
-#include <tclap/CmdLine.h>
 
 #include <chrono>
 #include <csignal>

--- a/cpp/selfplay.cpp
+++ b/cpp/selfplay.cpp
@@ -165,7 +165,7 @@ int MainCmds::selfplay(int argc, const char* const* argv) {
   string modelsDir;
   string outputDir;
   try {
-    TCLAP::CmdLine cmd("Generate training data via self play", ' ', Version::getKataGoVersionForHelp(),true);
+    KataGoCommandLine cmd("Generate training data via self play");
     TCLAP::ValueArg<string> configFileArg("","config-file","Config file to use",true,string(),"FILE");
     TCLAP::ValueArg<string> modelsDirArg("","models-dir","Dir to poll and load models from",true,string(),"DIR");
     TCLAP::ValueArg<string> outputDirArg("","output-dir","Dir to output files",true,string(),"DIR");

--- a/cpp/tune.cpp
+++ b/cpp/tune.cpp
@@ -29,8 +29,7 @@ int MainCmds::tuner(int argc, const char* const* argv) {
   int winograd3x3TileSize;
   bool full;
   try {
-    TCLAP::CmdLine cmd("Perform GPU tuning", ' ', Version::getKataGoVersionForHelp(),true);
-    TCLAP::ValueArg<string> modelFileArg("","model","Neural net model file to use",true,string(),"FILE");
+    KataGoCommandLine cmd("Perform GPU tuning");
     TCLAP::ValueArg<string> outputFileArg("","output","Filename to output tuning configration to",false,string(),"FILE");
     TCLAP::ValueArg<string> gpuIdxsArg("","gpus","Specific GPU/device number(s) to tune, comma-separated (default all)",false,string(),"GPUS");
     TCLAP::ValueArg<int> nnXLenArg("","xsize","Width of board to tune for",false,OpenCLTuner::DEFAULT_X_SIZE,"INT");
@@ -38,7 +37,6 @@ int MainCmds::tuner(int argc, const char* const* argv) {
     TCLAP::ValueArg<int> batchSizeArg("","batchsize","Batch size to tune for",false,OpenCLTuner::DEFAULT_BATCH_SIZE,"INT");
     TCLAP::ValueArg<int> winograd3x3TileSizeArg("","winograd3x3tilesize","Batch size to tune for",false,OpenCLTuner::DEFAULT_WINOGRAD_3X3_TILE_SIZE,"INT");
     TCLAP::SwitchArg fullArg("","full","Test more possible configurations");
-    cmd.add(modelFileArg);
     cmd.add(outputFileArg);
     cmd.add(gpuIdxsArg);
     cmd.add(nnXLenArg);
@@ -46,7 +44,7 @@ int MainCmds::tuner(int argc, const char* const* argv) {
     cmd.add(batchSizeArg);
     cmd.add(fullArg);
     cmd.parse(argc,argv);
-    modelFile = modelFileArg.getValue();
+    modelFile = cmd.modelFileArg.getValue();
     outputFile = outputFileArg.getValue();
     gpuIdxsStr = gpuIdxsArg.getValue();
     nnXLen = nnXLenArg.getValue();

--- a/cpp/tune.cpp
+++ b/cpp/tune.cpp
@@ -2,6 +2,7 @@
 #include "core/config_parser.h"
 #include "core/timer.h"
 #include "core/makedir.h"
+#include "commandline.h"
 #include "main.h"
 
 #ifdef USE_OPENCL_BACKEND
@@ -9,9 +10,6 @@
 #endif
 
 using namespace std;
-
-#define TCLAP_NAMESTARTSTRING "-" //Use single dashes for all flags
-#include <tclap/CmdLine.h>
 
 int MainCmds::tuner(int argc, const char* const* argv) {
 #ifndef USE_OPENCL_BACKEND

--- a/cpp/tune.cpp
+++ b/cpp/tune.cpp
@@ -30,6 +30,7 @@ int MainCmds::tuner(int argc, const char* const* argv) {
   bool full;
   try {
     KataGoCommandLine cmd("Perform GPU tuning");
+    cmd.addModelFileArg();
     TCLAP::ValueArg<string> outputFileArg("","output","Filename to output tuning configration to",false,string(),"FILE");
     TCLAP::ValueArg<string> gpuIdxsArg("","gpus","Specific GPU/device number(s) to tune, comma-separated (default all)",false,string(),"GPUS");
     TCLAP::ValueArg<int> nnXLenArg("","xsize","Width of board to tune for",false,OpenCLTuner::DEFAULT_X_SIZE,"INT");

--- a/cpp/write.cpp
+++ b/cpp/write.cpp
@@ -5,6 +5,7 @@
 #include "dataio/sgf.h"
 #include "dataio/lzparse.h"
 #include "dataio/datapool.h"
+#include "commandline.h"
 #include "main.h"
 #include <fstream>
 #include <algorithm>
@@ -17,9 +18,6 @@
 
 #include <H5Cpp.h>
 using namespace H5;
-
-#define TCLAP_NAMESTARTSTRING "-" //Use single dashes for all flags
-#include <tclap/CmdLine.h>
 
 using namespace std;
 


### PR DESCRIPTION
Hi there,

as I mentioned before, I would like KataGo to have a default path it looks at to find a network that can be provided either by the user, or by a package (like the home-brew one).

I have to say that my C++ is _quite_ rusty, so I would certainly need some guidance on how to cleanly achieve this within the coding style of KataGo - but this is my current thinking how this could be achieved.

My current plan is that the function `defaultNNModelPath()` can take a look into the home directory of the user into something like `~/.katago/default_network.txt.gz`, then fall back to a package provided place that is configured at compile time or provide the empty default if none of these are available. Something like this?

Of course the type `KataGoCommandLine` needs to be extracted / renamed / moved to a central. location - but only if the direction I'm going here is actually something that you could endorse.

So, what do you think?