### PR TITLE
Allow KataGo to use CPU

### DIFF
--- a/cpp/neuralnet/openclhelpers.cpp
+++ b/cpp/neuralnet/openclhelpers.cpp
@@ -219,12 +219,12 @@ vector<DeviceInfo> DeviceInfo::getAllDeviceInfosOnSystem(Logger* logger) {
 
     cl_uint numDevices;
     err = clGetDeviceIDs(
-      platformIds[platformIdx], CL_DEVICE_TYPE_GPU | CL_DEVICE_TYPE_ACCELERATOR, deviceIds.size() - numDevicesTotal,
+      platformIds[platformIdx], CL_DEVICE_TYPE_CPU | CL_DEVICE_TYPE_GPU | CL_DEVICE_TYPE_ACCELERATOR, deviceIds.size() - numDevicesTotal,
       deviceIds.data() + numDevicesTotal, &numDevices);
     //Allow there to be 0 devices on this platform, just move on to the next
     if(err == CL_DEVICE_NOT_FOUND) {
       if(logger != NULL)
-        logger->write("Found 0 device(s) on platform " + Global::intToString(platformIdx) + " with type GPU or Accelerator, skipping");
+        logger->write("Found 0 device(s) on platform " + Global::intToString(platformIdx) + " with type CPU or GPU or Accelerator, skipping");
       continue;
     }
 

--- a/cpp/neuralnet/openclhelpers.cpp
+++ b/cpp/neuralnet/openclhelpers.cpp
@@ -232,7 +232,7 @@ vector<DeviceInfo> DeviceInfo::getAllDeviceInfosOnSystem(Logger* logger) {
     assert(numDevices <= deviceIds.size());
     numDevicesTotal += numDevices;
     if(logger != NULL)
-      logger->write("Found " + Global::intToString(numDevices) + " device(s) on platform " + Global::intToString(platformIdx) + " with type GPU or Accelerator");
+      logger->write("Found " + Global::intToString(numDevices) + " device(s) on platform " + Global::intToString(platformIdx) + " with type CPU or GPU or Accelerator");
   }
   deviceIds.resize(numDevicesTotal);
 


### PR DESCRIPTION
Was trying to set up a one-playout katago on a CPU-only VPS only to find out that CPUs aren't allowed for some reason. I can't see any reason why we shouldn't allow KataGo to run on the CPU. I get 1 playout per second, which is pretty slow, but considering that KataGo 1 playout is stronger than Leela 11 at 10k playouts, it's far from unusable. Thoughts?