### PR TITLE
implement priority for analysis engine

### DIFF
--- a/cpp/core/global.h
+++ b/cpp/core/global.h
@@ -17,6 +17,7 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
+#include <queue>
 
 //GLOBAL DEFINES AND FLAGS----------------------------------------------------
 #ifdef __GNUG__  //On g++ only


### PR DESCRIPTION
Implements #179 

tested and found working with https://github.com/sanderland/katrain/pull/12
after loading an sgf and rewinding, you can analyze moves near the beginning. of course there is some small delay since you need to wait for an analysis thread to free up, but it's much better than before.