### PR TITLE
overrideSettings in analysis

### DIFF
--- a/cpp/core/config_parser.cpp
+++ b/cpp/core/config_parser.cpp
@@ -28,6 +28,16 @@ ConfigParser::ConfigParser(const map<string, string>& kvs)
   initialize(kvs);
 }
 
+ConfigParser::ConfigParser(const ConfigParser& source) {
+  if(!source.initialized)
+    throw StringError("Can only copy a ConfigParser which has been initialized.");
+  initialized = source.initialized;
+  fileName = source.fileName;
+  contents = source.contents;
+  keyValues = source.keyValues;
+  usedKeys = source.usedKeys;
+}
+
 void ConfigParser::initialize(const string& fname) {
   if(initialized)
     throw StringError("ConfigParser already initialized, cannot initialize again");
@@ -52,6 +62,8 @@ void ConfigParser::initialize(const map<string, string>& kvs) {
   keyValues = kvs;
   initialized = true;
 }
+
+
 
 void ConfigParser::initializeInternal(istream& in) {
   int lineNum = 0;
@@ -99,7 +111,7 @@ void ConfigParser::overrideKeys(const map<string, string>& newkvs) {
     else
       keyValues[iter->first] = iter->second;
   }
-  fileName += " and/or command-line overrides";
+  fileName += " and/or command-line and query overrides";
 }
 
 

--- a/cpp/core/config_parser.h
+++ b/cpp/core/config_parser.h
@@ -22,9 +22,9 @@ class ConfigParser {
   ConfigParser(const std::string& file);
   ConfigParser(std::istream& in);
   ConfigParser(const std::map<std::string, std::string>& kvs);
+  ConfigParser(const ConfigParser& source);
   ~ConfigParser();
 
-  ConfigParser(const ConfigParser& other) = delete;
   ConfigParser& operator=(const ConfigParser& other) = delete;
   ConfigParser(ConfigParser&& other) = delete;
   ConfigParser& operator=(ConfigParser&& other) = delete;

--- a/cpp/core/threadsafequeue.h
+++ b/cpp/core/threadsafequeue.h
@@ -26,6 +26,7 @@ class ThreadSafeContainer
   virtual T popUnsynchronized() = 0;
   virtual void clearUnsynchronized() = 0;
   virtual size_t sizeUnsynchronized() = 0;
+  virtual bool empty() = 0;
 
  public:
   inline ThreadSafeContainer()
@@ -185,6 +186,10 @@ class ThreadSafeQueue final : public ThreadSafeContainer<T>
     return elts.size() - headIdx;
   }
 
+  inline bool empty() override {
+    return elts.empty();
+  }
+
 };
 
 //Will return the elements with HIGHEST KT first, according to the comparison on KT.
@@ -221,6 +226,9 @@ class ThreadSafePriorityQueue final : public ThreadSafeContainer<std::pair<KT,VT
     return queue.size();
   }
 
+  inline bool empty() override {
+    return queue.empty();
+  }
 };
 
 


### PR DESCRIPTION
started with a single setting and ended up with this.
- allows for overriding most settings in the config file with an overrideSettings field
- Unrelated, also makes the process exit nicer so you can
   ./katago analysis ... < input.in
   and it will finish all queries before exiting. I wasn't sure why it's currently killing queries so harsh when finding EOF, so happy to not have this in if there's a good reason.

Docs are todo, but thought I'd first pass this by you in case you're very opposed :)
