### PR TITLE
Make katago solve dead-alive go problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ __pycache__
 *.cbp
 
 tmp*.txt
-
+test/
+.vscode/
 cpp/write
 cpp/runtests
 cpp/example

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "functional": "cpp"
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "functional": "cpp"
+    }
+}

--- a/cpp/command/gtp.cpp
+++ b/cpp/command/gtp.cpp
@@ -1168,7 +1168,10 @@ struct GTPEngine {
 
 
 //User should pre-fill pla with a default value, as it will not get filled in if the parsed command doesn't specify
-static GTPEngine::AnalyzeArgs parseAnalyzeCommand(const string& command, const vector<string>& pieces, Player& pla, bool& parseFailed) {
+static GTPEngine::AnalyzeArgs parseAnalyzeCommand(const string& command, const vector<string>& pieces, GTPEngine* engine, bool& parseFailed) {
+  Player pla = engine->bot->getRootPla();
+  Board board = engine->bot->getRootBoard();
+
   int numArgsParsed = 0;
 
   bool isLZ = (command == "lz-analyze" || command == "lz-genmove_analyze");
@@ -1243,9 +1246,9 @@ static GTPEngine::AnalyzeArgs parseAnalyzeCommand(const string& command, const v
     }
     else if(isKata && key == "ownership" && Global::tryStringToBool(value,showOwnership)) {
       continue;
-    } else if(isKata && key == "topleft" && Location::tryOfString(value, bot->getRootBoard(), problemAnalyzeTopLeftCorner)) {
+    } else if(isKata && key == "topleft" && Location::tryOfString(value, board, problemAnalyzeTopLeftCorner)) {
       continue;
-    } else if(isKata && key == "bottomright" && Location::tryOfString(value, bot->getRootBoard(), problemAnalyzeBottomRightCorner)) {
+    } else if(isKata && key == "bottomright" && Location::tryOfString(value, board, problemAnalyzeBottomRightCorner)) {
       continue;
     }
 
@@ -2022,7 +2025,7 @@ int MainCmds::gtp(int argc, const char* const* argv) {
     else if(command == "genmove_analyze" || command == "lz-genmove_analyze" || command == "kata-genmove_analyze") {
       Player pla = engine->bot->getRootPla();
       bool parseFailed = false;
-      GTPEngine::AnalyzeArgs args = parseAnalyzeCommand(command, pieces, pla, parseFailed);
+      GTPEngine::AnalyzeArgs args = parseAnalyzeCommand(command, pieces, engine, parseFailed);
       if(parseFailed) {
         responseIsError = true;
         response = "Could not parse genmove_analyze arguments or arguments out of range: '" + Global::concat(pieces," ") + "'";
@@ -2363,7 +2366,7 @@ int MainCmds::gtp(int argc, const char* const* argv) {
     else if(command == "analyze" || command == "lz-analyze" || command == "kata-analyze" || command == "kata-problem_analyze") {
       Player pla = engine->bot->getRootPla();
       bool parseFailed = false;
-      GTPEngine::AnalyzeArgs args = parseAnalyzeCommand(command, pieces, pla, parseFailed);
+      GTPEngine::AnalyzeArgs args = parseAnalyzeCommand(command, pieces, engine, parseFailed);
 
       if(parseFailed) {
         responseIsError = true;

--- a/cpp/command/gtp.cpp
+++ b/cpp/command/gtp.cpp
@@ -69,7 +69,7 @@ static const vector<string> knownCommands = {
   // "analyze",
   "lz-analyze",
   "kata-analyze",
-
+  "kata-problem_analyze",
   //Display raw neural net evaluations
   "kata-raw-nn",
 

--- a/cpp/search/asyncbot.cpp
+++ b/cpp/search/asyncbot.cpp
@@ -87,6 +87,22 @@ void AsyncBot::setAlwaysIncludeOwnerMap(bool b) {
   stopAndWait();
   search->setAlwaysIncludeOwnerMap(b);
 }
+
+void AsyncBot::setProblemAnalyze(bool b) {
+  stopAndWait();
+  search->setProblemAnalyze(b);
+}
+
+void AsyncBot::setProblemAnalyzeTopLeft(Loc b) {
+  stopAndWait();
+  search->setProblemAnalyzeTopLeft(b);
+}
+
+void AsyncBot::setProblemAnalyzeBottomRightCorner(Loc b) {
+  stopAndWait();
+  search->setProblemAnalyzeBottomRightCorner(b);
+}
+
 void AsyncBot::setParams(SearchParams params) {
   stopAndWait();
   search->setParams(params);

--- a/cpp/search/asyncbot.cpp
+++ b/cpp/search/asyncbot.cpp
@@ -93,9 +93,9 @@ void AsyncBot::setProblemAnalyze(bool b) {
   search->setProblemAnalyze(b);
 }
 
-void AsyncBot::setProblemAnalyzeTopLeft(Loc b) {
+void AsyncBot::setProblemAnalyzeTopLeftCorner(Loc b) {
   stopAndWait();
-  search->setProblemAnalyzeTopLeft(b);
+  search->setProblemAnalyzeTopLeftCorner(b);
 }
 
 void AsyncBot::setProblemAnalyzeBottomRightCorner(Loc b) {

--- a/cpp/search/asyncbot.h
+++ b/cpp/search/asyncbot.h
@@ -33,6 +33,9 @@ class AsyncBot {
   void setRootPassLegal(bool b);
   void setRootHintLoc(Loc loc);
   void setAlwaysIncludeOwnerMap(bool b);
+  void setProblemAnalyze(bool b);
+  void setProblemAnalyzeTopLeftCorner(Loc b);
+  void setProblemAnalyzeBottomRightCorner(Loc b);
   void setParams(SearchParams params);
   void setPlayerIfNew(Player movePla);
   void clearSearch();

--- a/cpp/search/search.cpp
+++ b/cpp/search/search.cpp
@@ -978,18 +978,18 @@ void Search::maybeAddPolicyNoiseAndTempAlreadyLocked(SearchThread& thread, Searc
   }
 }
 
-bool search::isInProblemArea(Loc moveLoc) const {
+bool Search::isInProblemArea(Loc moveLoc) const {
   assert(moveLoc == Board::PASS_LOC || rootBoard.isOnBoard(moveLoc));
   if (problemAnalyzeTopLeftCorner == Board::NULL_LOC || problemAnalyzeBottomRightCorner == Board::NULL_LOC) {
     // not limit
     return true;
   }
-  int x = Location::getX(moveLoc);
-  int y = Location::getY(moveLoc);
-  int x1 = Location::getX(problemAnalyzeTopLeftCorner);
-  int x2 = Location::getX(problemAnalyzeBottomRightCorner);
-  int y1 = Location::getY(problemAnalyzeTopLeftCorner);
-  int y2 = Location::getY(problemAnalyzeBottomRightCorner);
+  int x = Location::getX(moveLoc, rootBoard.x_size);
+  int y = Location::getY(moveLoc, rootBoard.x_size);
+  int x1 = Location::getX(problemAnalyzeTopLeftCorner, rootBoard.x_size);
+  int x2 = Location::getX(problemAnalyzeBottomRightCorner, rootBoard.x_size);
+  int y1 = Location::getY(problemAnalyzeTopLeftCorner, rootBoard.x_size);
+  int y2 = Location::getY(problemAnalyzeBottomRightCorner, rootBoard.x_size);
   if (x1 > x2) {
     // swap
     int tmp = x1;

--- a/cpp/search/search.cpp
+++ b/cpp/search/search.cpp
@@ -1849,7 +1849,7 @@ void Search::playoutDescend(
   //The absurdly rare case that the move chosen is not legal
   //(this should only happen either on a bug or where the nnHash doesn't have full legality information or when there's an actual hash collision).
   //Regenerate the neural net call and continue
-  if(!thread.history.isLegal(thread.board,bestChildMoveLoc,thread.pla)) {
+  if(!thread.history.isLegal(thread.board,bestChildMoveLoc,thread.pla) && !isProblemAnalyze) {
     bool isReInit = true;
     initNodeNNOutput(thread,node,isRoot,true,0,isReInit);
 

--- a/cpp/search/search.h
+++ b/cpp/search/search.h
@@ -327,7 +327,8 @@ private:
   int getPos(Loc moveLoc) const;
 
   bool isAllowedRootMove(Loc moveLoc) const;
-
+  bool isInProblemArea(Loc moveLoc) const;
+  
   void computeRootValues();
 
   double getScoreUtility(double scoreMeanSum, double scoreMeanSqSum, double weightSum) const;

--- a/cpp/search/search.h
+++ b/cpp/search/search.h
@@ -147,6 +147,10 @@ struct Search {
 
   bool alwaysIncludeOwnerMap;
 
+  bool isProblemAnalyze;
+  Loc problemAnalyzeTopLeftCorner;
+  Loc problemAnalyzeBottomRightCorner;
+
   SearchParams searchParams;
   int64_t numSearchesBegun;
   uint32_t searchNodeAge;
@@ -201,6 +205,9 @@ struct Search {
   void setKomiIfNew(float newKomi); //Does not clear history, does clear search unless komi is equal.
   void setRootPassLegal(bool b);
   void setRootHintLoc(Loc hintLoc);
+  void setProblemAnalyze(bool b);
+  void setProblemAnalyzeTopLeftCorner(Loc b);
+  void setProblemAnalyzeBottomRightCorner(Loc b);
   void setAlwaysIncludeOwnerMap(bool b);
   void setParams(SearchParams params);
   void setParamsNoClearing(SearchParams params); //Does not clear search

--- a/docs/GTP_Extensions.md
+++ b/docs/GTP_Extensions.md
@@ -104,7 +104,15 @@ In addition to a basic set of [GTP commands](https://www.lysator.liu.se/~gunnar/
      * Like `lz-analyze`, will immediately begin printing a partial GTP response, with a new line every `interval` centiseconds.
      * Unlike `lz-analyze`, will teriminate on its own after the normal amount of time that a `genmove` would take and will NOT terminate prematurely or asynchronously upon recipt of a newline or an additional GTP command.
      * The final move made will be reported as a single line `play <vertex or "pass" or "resign">`, followed by the usual double-newline that signals a complete GTP response.
-  * `kata-genmove_analyze [player (optional)] [interval (optional)] KEYVALUEPAIR KEYVALUEPAIR`
+  * `kata-problem_analyze [player (optional)] [interval (optional)] KEYVALUEPAIR KEYVALUEPAIR`
+     * this extented GTP command is used for solving life-dead problems. 
+     * Same as `kata-analyze` except with the options and fields :
+     * Additional possible key-value pairs:
+       * `topleft M19` - Sets the problem valid area - the top left corner
+       * `bottomright T14` - Sets the problem valid area - the bottom right corner
+     * if `topoleft` or `bottomright` is not set, use the full board.
+     
+   * `kata-genmove_analyze [player (optional)] [interval (optional)] KEYVALUEPAIR KEYVALUEPAIR`
      * Same as `lz-genmove_analyze` except with the options and fields of `kata-analyze` rather than `lz-analyze`
   * `analyze, genmove_analyze`
      * Same as `kata-analyze` and `kata-genmove_analyze`, but intended specifically for the Sabaki GUI app in that all floating point values are always formatted with a decimal point, even when a value happens to be an integer. May also have slightly less compact output in other ways (e.g. extra trailing zeros on some decimals).


### PR DESCRIPTION
Make katago to solve dead-alive go problems by adding a new extented GTP command:

  * `kata-problem_analyze [player (optional)] [interval (optional)] KEYVALUEPAIR KEYVALUEPAIR`
     * this extented GTP command is used for solving life-dead problems. 
     * Same as `kata-analyze` except with the options and fields :
     * Additional possible key-value pairs:
       * `topleft M19` - Sets the problem valid area - the top left corner
       * `bottomright T14` - Sets the problem valid area - the bottom right corner
     * if `topoleft` or `bottomright` is not set, use the full board.