### PR TITLE
Anti-mirror logic

### DIFF
--- a/cpp/command/gtp.cpp
+++ b/cpp/command/gtp.cpp
@@ -314,6 +314,8 @@ struct GTPEngine {
   bool staticPDATakesPrecedence;
   double genmoveWideRootNoise;
   double analysisWideRootNoise;
+  bool genmoveAntiMirror;
+  bool analysisAntiMirror;
 
   NNEvaluator* nnEval;
   AsyncBot* bot;
@@ -346,6 +348,7 @@ struct GTPEngine {
     double dynamicPDACapPerOppLead, double staticPDA, bool staticPDAPrecedence,
     bool avoidDagger,
     double genmoveWRN, double analysisWRN,
+    bool genmoveAntiMir, bool analysisAntiMir,
     Player persp, int pvLen
   )
     :nnModelFile(modelFile),
@@ -357,6 +360,8 @@ struct GTPEngine {
      staticPDATakesPrecedence(staticPDAPrecedence),
      genmoveWideRootNoise(genmoveWRN),
      analysisWideRootNoise(analysisWRN),
+     genmoveAntiMirror(genmoveAntiMir),
+     analysisAntiMirror(analysisAntiMir),
      nnEval(NULL),
      bot(NULL),
      currentRules(initialRules),
@@ -762,6 +767,10 @@ struct GTPEngine {
       params.wideRootNoise = genmoveWideRootNoise;
       bot->setParams(params);
     }
+    if(params.antiMirror != genmoveAntiMirror) {
+      params.antiMirror = genmoveAntiMirror;
+      bot->setParams(params);
+    }
 
     //Play faster when winning
     double searchFactor = PlayUtils::getSearchFactor(searchFactorWhenWinningThreshold,searchFactorWhenWinning,params,recentWinLossValues,pla);
@@ -1002,6 +1011,10 @@ struct GTPEngine {
     //Also wide root, if desired
     if(params.wideRootNoise != analysisWideRootNoise) {
       params.wideRootNoise = analysisWideRootNoise;
+      bot->setParams(params);
+    }
+    if(params.antiMirror != analysisAntiMirror) {
+      params.antiMirror = analysisAntiMirror;
       bot->setParams(params);
     }
 
@@ -1364,6 +1377,9 @@ int MainCmds::gtp(int argc, const char* const* argv) {
   const double genmoveWideRootNoise = initialParams.wideRootNoise;
   const double analysisWideRootNoise =
     cfg.contains("analysisWideRootNoise") ? cfg.getDouble("analysisWideRootNoise",0.0,5.0) : genmoveWideRootNoise;
+  const double analysisAntiMirror = initialParams.antiMirror;
+  const double genmoveAntiMirror =
+    cfg.contains("genmoveAntiMirror") ? cfg.getBool("genmoveAntiMirror") : cfg.contains("antiMirror") ? cfg.getBool("antiMirror") : true;
 
   Player perspective = Setup::parseReportAnalysisWinrates(cfg,C_EMPTY);
 
@@ -1374,6 +1390,7 @@ int MainCmds::gtp(int argc, const char* const* argv) {
     staticPlayoutDoublingAdvantage,staticPDATakesPrecedence,
     avoidMYTDaggerHack,
     genmoveWideRootNoise,analysisWideRootNoise,
+    genmoveAntiMirror,analysisAntiMirror,
     perspective,analysisPVLen
   );
   engine->setOrResetBoardSize(cfg,logger,seedRand,defaultBoardXSize,defaultBoardYSize);

--- a/cpp/game/board.cpp
+++ b/cpp/game/board.cpp
@@ -61,6 +61,25 @@ bool Location::isAdjacent(Loc loc0, Loc loc1, int x_size)
   return loc0 == loc1 - (x_size+1) || loc0 == loc1 - 1 || loc0 == loc1 + 1 || loc0 == loc1 + (x_size+1);
 }
 
+Loc Location::getMirrorLoc(Loc loc, int x_size, int y_size) {
+  if(loc == Board::NULL_LOC || loc == Board::PASS_LOC)
+    return loc;
+  return getLoc(x_size-1-getX(loc,x_size),y_size-1-getY(loc,x_size),x_size);
+}
+
+Loc Location::getCenterLoc(int x_size, int y_size) {
+  if(x_size % 2 == 0 || y_size % 2 == 0)
+    return Board::NULL_LOC;
+  return getLoc(x_size / 2, y_size / 2, x_size);
+}
+
+bool Location::isCentral(Loc loc, int x_size, int y_size) {
+  int x = getX(loc,x_size);
+  int y = getY(loc,x_size);
+  return x >= (x_size-1)/2 && x <= x_size/2 && y >= (y_size-1)/2 && y <= y_size/2;
+}
+
+
 #define FOREACHADJ(BLOCK) {int ADJOFFSET = -(x_size+1); {BLOCK}; ADJOFFSET = -1; {BLOCK}; ADJOFFSET = 1; {BLOCK}; ADJOFFSET = x_size+1; {BLOCK}};
 #define ADJ0 (-(x_size+1))
 #define ADJ1 (-1)
@@ -507,6 +526,27 @@ bool Board::isAdjacentToPla(Loc loc, Player pla) const {
   );
   return false;
 }
+
+bool Board::isAdjacentOrDiagonalToPla(Loc loc, Player pla) const {
+  for(int i = 0; i<8; i++) {
+    Loc adj = loc + adj_offsets[i];
+    if(colors[adj] == pla)
+      return true;
+  }
+  return false;
+}
+
+bool Board::isAdjacentToChain(Loc loc, Loc chain) const {
+  if(colors[chain] == C_EMPTY)
+    return false;
+  FOREACHADJ(
+    Loc adj = loc + ADJOFFSET;
+    if(colors[adj] == colors[chain] && chain_head[adj] == chain_head[chain])
+      return true;
+  );
+  return false;
+}
+
 
 //Does this connect two pla distinct groups that are not both pass-alive and not within opponent pass-alive area either?
 bool Board::isNonPassAliveSelfConnection(Loc loc, Player pla, Color* passAliveArea) const {

--- a/cpp/game/board.h
+++ b/cpp/game/board.h
@@ -49,6 +49,9 @@ namespace Location
 
   void getAdjacentOffsets(short adj_offsets[8], int x_size);
   bool isAdjacent(Loc loc0, Loc loc1, int x_size);
+  Loc getMirrorLoc(Loc loc, int x_size, int y_size);
+  Loc getCenterLoc(int x_size, int y_size);
+  bool isCentral(Loc loc, int x_size, int y_size);
   int distance(Loc loc0, Loc loc1, int x_size);
   int euclideanDistanceSquared(Loc loc0, Loc loc1, int x_size);
 
@@ -173,6 +176,9 @@ struct Board
   Loc getKoCaptureLoc(Loc loc, Player pla) const;
   //Check if this location is adjacent to stones of the specified color
   bool isAdjacentToPla(Loc loc, Player pla) const;
+  bool isAdjacentOrDiagonalToPla(Loc loc, Player pla) const;
+  //Check if this location is adjacent a given chain.
+  bool isAdjacentToChain(Loc loc, Loc chain) const;
   //Does this connect two pla distinct groups that are not both pass-alive and not within opponent pass-alive area either?
   bool isNonPassAliveSelfConnection(Loc loc, Player pla, Color* passAliveArea) const;
   //Is this board empty?

--- a/cpp/program/setup.cpp
+++ b/cpp/program/setup.cpp
@@ -488,6 +488,10 @@ vector<SearchParams> Setup::loadParams(
     else
       params.nnPolicyTemperature = 1.0f;
 
+    if(cfg.contains("antiMirror"+idxStr)) params.antiMirror = cfg.getBool("antiMirror"+idxStr);
+    else if(cfg.contains("antiMirror"))   params.antiMirror = cfg.getBool("antiMirror");
+    else                                  params.antiMirror = false;
+
     if(cfg.contains("mutexPoolSize"+idxStr)) params.mutexPoolSize = (uint32_t)cfg.getInt("mutexPoolSize"+idxStr, 1, 1 << 24);
     else if(cfg.contains("mutexPoolSize"))   params.mutexPoolSize = (uint32_t)cfg.getInt("mutexPoolSize",        1, 1 << 24);
     else                                     params.mutexPoolSize = 16384;

--- a/cpp/search/search.h
+++ b/cpp/search/search.h
@@ -145,6 +145,11 @@ struct Search {
   //Used to center for dynamic scorevalue
   double recentScoreCenter;
 
+  //If the opponent is mirroring, then the color of that opponent, for countering mirroring
+  Player mirroringPla;
+  double mirrorAdvantage; //Number of points the opponent wins by if mirror holds indefinitely.
+  bool mirrorCenterIsSymmetric;
+
   bool alwaysIncludeOwnerMap;
 
   SearchParams searchParams;
@@ -308,6 +313,8 @@ struct Search {
   void runSinglePlayout(SearchThread& thread);
 
   //Helpers-----------------------------------------------------------------------
+  int getPos(Loc moveLoc) const;
+
 private:
   static constexpr double POLICY_ILLEGAL_SELECTION_VALUE = -1e50;
 
@@ -317,7 +324,6 @@ private:
   double interpolateEarly(double halflife, double earlyValue, double value) const;
 
   void maybeAddPolicyNoiseAndTempAlreadyLocked(SearchThread& thread, SearchNode& node, bool isRoot) const;
-  int getPos(Loc moveLoc) const;
 
   bool isAllowedRootMove(Loc moveLoc) const;
 

--- a/cpp/search/searchparams.cpp
+++ b/cpp/search/searchparams.cpp
@@ -46,6 +46,7 @@ SearchParams::SearchParams()
    playoutDoublingAdvantage(0.0),
    playoutDoublingAdvantagePla(C_EMPTY),
    nnPolicyTemperature(1.0f),
+   antiMirror(false),
    mutexPoolSize(8192),
    numVirtualLossesPerThread(3),
    numThreads(1),

--- a/cpp/search/searchparams.h
+++ b/cpp/search/searchparams.h
@@ -60,6 +60,7 @@ struct SearchParams {
   Player playoutDoublingAdvantagePla; //Negate playoutDoublingAdvantage when making a move for the opponent of this player. If empty, opponent of the root player.
 
   float nnPolicyTemperature; //Scale neural net policy probabilities by this temperature, applies everywhere in the tree
+  bool antiMirror; //Enable anti-mirroring logic
 
   //Threading-related
   uint32_t mutexPoolSize; //Size of mutex pool for synchronizing access to all search nodes


### PR DESCRIPTION
Just for fun - a feature to maybe kinda do better in mirror Go when the opponent holds an 90+% advantage (e.g. reverse komi mirror go), as opposed to even-game mirror go, which is much easier to handle.