### PR TITLE
Make multiple contexts per platform to avoid false dependency

### DIFF
--- a/cpp/neuralnet/openclhelpers.cpp
+++ b/cpp/neuralnet/openclhelpers.cpp
@@ -458,23 +458,25 @@ DevicesContext::DevicesContext(const vector<DeviceInfo>& allDeviceInfos, const v
     deviceIdsToUse.push_back(allDeviceInfos[gpuIdx].deviceId);
   }
 
+  //Collect all platforms from all the devices we are actually using, with multiplicity
+  //In theory, we should only be making one of these per opencl platform.
+  //In practice, doing this for NVIDIA introduces a false dependency where only one GPU will get
+  //used at a time, each one locking out the others when used. Separate contexts for the same
+  //platform is a workaround.
   for(size_t i = 0; i<gpuIdxsToUse.size(); i++) {
     int gpuIdx = gpuIdxsToUse[i];
     const DeviceInfo& deviceInfo = allDeviceInfos[gpuIdx];
     cl_device_id deviceId = deviceInfo.deviceId;
     cl_platform_id platformId = deviceInfo.platformId;
-    if(!contains(initializedPlatforms,platformId)) {
-      InitializedPlatform* initializedPlatform = new InitializedPlatform();
-      initializedPlatform->platformId = platformId;
-      initializedPlatform->platformDesc = deviceInfo.platformDesc;
-      initializedPlatforms[platformId] = initializedPlatform;
-    }
-    InitializedPlatform* initializedPlatform = initializedPlatforms[platformId];
+    InitializedPlatform* initializedPlatform = new InitializedPlatform();
+    initializedPlatform->platformId = platformId;
+    initializedPlatform->platformDesc = deviceInfo.platformDesc;
     initializedPlatform->deviceIdsToUseForThisPlatform.push_back(deviceId);
+    initializedPlatforms.push_back(initializedPlatform);
   }
 
   for(auto iter = initializedPlatforms.begin(); iter != initializedPlatforms.end(); ++iter) {
-    InitializedPlatform* initializedPlatform = iter->second;
+    InitializedPlatform* initializedPlatform = *iter;
     cl_platform_id platformId = initializedPlatform->platformId;
     initializedPlatform->properties.push_back(CL_CONTEXT_PLATFORM);
     initializedPlatform->properties.push_back((cl_context_properties)platformId);
@@ -504,8 +506,7 @@ DevicesContext::DevicesContext(const vector<DeviceInfo>& allDeviceInfos, const v
     int gpuIdx = gpuIdxsToUse[i];
     const DeviceInfo& deviceInfo = allDeviceInfos[gpuIdx];
     cl_device_id deviceId = deviceInfo.deviceId;
-    cl_platform_id platformId = deviceInfo.platformId;
-    cl_context context = initializedPlatforms[platformId]->context;
+    cl_context context = initializedPlatforms[i]->context;
 
     //TODO - someday, maybe consider CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE
     cl_int err;
@@ -550,7 +551,7 @@ DevicesContext::~DevicesContext() {
   }
 
   for(auto iter = initializedPlatforms.begin(); iter != initializedPlatforms.end(); ++iter) {
-    InitializedPlatform* initializedPlatform = iter->second;
+    InitializedPlatform* initializedPlatform = *iter;
     clReleaseContext(initializedPlatform->context);
     delete initializedPlatform;
   }

--- a/cpp/neuralnet/openclhelpers.h
+++ b/cpp/neuralnet/openclhelpers.h
@@ -53,8 +53,9 @@ struct InitializedDevice {
 struct DevicesContext {
   //Index of the default device to use if not specified (user-provided gpuIdx == -1)
   int defaultGpuIdx;
-  //All platforms with for which we made a context, for freeing each exactly once in destructor
-  std::map<cl_platform_id,InitializedPlatform*> initializedPlatforms;
+  //All platforms with for which we made a context
+  //A platform might be in here more than once, with different contexts
+  std::vector<InitializedPlatform*> initializedPlatforms;
 
   //Filtered and initialized subset of allDeviceInfos
   std::vector<InitializedDevice*> devicesToUse;


### PR DESCRIPTION
In theory, only one OpenCL context should be needed per platform, but NVIDIA GPUs seem to have an issue in OpenCL where using one GPU locks out the others, even if the command queues, data buffers, computations sent to each one are completely independent of each other, perhaps due to the details of their implementation relative to other vendors.

Try to work around this fact by creating multiple OpenCL contexts per platform, so that each GPU sits in an entirely different context.