### PR TITLE
Return ownership for all candidate moves

### DIFF
--- a/cpp/search/search.h
+++ b/cpp/search/search.h
@@ -311,7 +311,7 @@ struct Search {
   //Must have ownership present on all neural net evals.
   //Safe to call DURING search, but NOT necessarily safe to call multithreadedly when updating the root position
   //or changing parameters or clearing search.
-  std::vector<double> getAverageTreeOwnership(int64_t minVisits) const;
+  std::vector<double> getAverageTreeOwnership(int64_t minVisit,const SearchNode* node=NULL) const;
 
   //Expert manual playout-by-playout interface------------------------------------------------
   void beginSearch(bool pondering);

--- a/cpp/search/searchresults.cpp
+++ b/cpp/search/searchresults.cpp
@@ -1160,7 +1160,8 @@ void Search::printTreeHelper(
 }
 
 
-vector<double> Search::getAverageTreeOwnership(int64_t minVisits) const {
+vector<double> Search::getAverageTreeOwnership(int64_t minVisits,const SearchNode* node) const {
+  if(node==NULL) node = rootNode;
   if(!alwaysIncludeOwnerMap)
     throw StringError("Called Search::getAverageTreeOwnership when alwaysIncludeOwnerMap is false");
   vector<double> vec(nnXLen*nnYLen,0.0);

--- a/cpp/search/searchresults.cpp
+++ b/cpp/search/searchresults.cpp
@@ -1165,7 +1165,7 @@ vector<double> Search::getAverageTreeOwnership(int64_t minVisits,const SearchNod
   if(!alwaysIncludeOwnerMap)
     throw StringError("Called Search::getAverageTreeOwnership when alwaysIncludeOwnerMap is false");
   vector<double> vec(nnXLen*nnYLen,0.0);
-  getAverageTreeOwnershipHelper(vec,minVisits,1.0,rootNode);
+  getAverageTreeOwnershipHelper(vec,minVisits,1.0,node);
   return vec;
 }
 


### PR DESCRIPTION
This includes the ownership map in all 'moveInfos' objects for the analysis engine.

Probably needs some cleaning up and could be optimized, but opening this PR to see if you're interested in including this.
I'm using it to experiment with 'simple moves' AIs on the front-end side.