### PR TITLE
Implement periodic partial reports and termination in analysis engine

### DIFF
--- a/cpp/command/analysis.cpp
+++ b/cpp/command/analysis.cpp
@@ -506,7 +506,12 @@ int MainCmds::analysis(int argc, const char* const* argv) {
     //Special actions
     if(input.find("action") != input.end() && input["action"].is_string()) {
       string action = input["action"].get<string>();
-      if(action == "terminate") {
+      if(action == "query_version") {
+        input["version"] = Version::getKataGoVersion();
+        input["git_hash"] = Version::getGitRevision();
+        pushToWrite(new string(input.dump()));
+      }
+      else if(action == "terminate") {
 
         bool terminateIdFound = false;
         string terminateId;
@@ -568,8 +573,9 @@ int MainCmds::analysis(int argc, const char* const* argv) {
         pushToWrite(new string(input.dump()));
       }
       else {
-        reportError("'action' field must be 'terminate', no other actions currently supported");
+        reportError("'action' field must be 'query_version' or 'terminate'");
       }
+
       continue;
     }
 

--- a/cpp/command/gtp.cpp
+++ b/cpp/command/gtp.cpp
@@ -811,7 +811,7 @@ struct GTPEngine {
         bot->setAlwaysIncludeOwnerMap(true);
       else
         bot->setAlwaysIncludeOwnerMap(false);
-      moveLoc = bot->genMoveSynchronousAnalyze(pla, tc, searchFactor, args.secondsPerReport, callback);
+      moveLoc = bot->genMoveSynchronousAnalyze(pla, tc, searchFactor, args.secondsPerReport, &callback);
       //Make sure callback happens at least once
       callback(bot->getSearch());
     }
@@ -1046,7 +1046,7 @@ struct GTPEngine {
       bot->setParams(params);
     }
 
-    std::function<void(Search* search)> callback = getAnalyzeCallback(pla,args);
+    std::function<void(const Search* search)> callback = getAnalyzeCallback(pla,args);
     bot->setAvoidMoveUntilByLoc(args.avoidMoveUntilByLocBlack,args.avoidMoveUntilByLocWhite);
     if(args.showOwnership)
       bot->setAlwaysIncludeOwnerMap(true);
@@ -1054,7 +1054,7 @@ struct GTPEngine {
       bot->setAlwaysIncludeOwnerMap(false);
 
     double searchFactor = 1e40; //go basically forever
-    bot->analyze(pla, searchFactor, args.secondsPerReport, callback);
+    bot->analyze(pla, searchFactor, args.secondsPerReport, &callback);
   }
 
   double computeLead(Logger& logger) {

--- a/cpp/command/misc.cpp
+++ b/cpp/command/misc.cpp
@@ -458,7 +458,7 @@ int MainCmds::demoplay(int argc, const char* const* argv) {
 
     double callbackPeriod = 0.05;
 
-    auto callback = [&baseHist,&recentWinLossValues,&recentScores,&recentScoreStdevs](const Search* search) {
+    std::function<void(const Search*)> callback = [&baseHist,&recentWinLossValues,&recentScores,&recentScoreStdevs](const Search* search) {
       writeLine(search,baseHist,recentWinLossValues,recentScores,recentScoreStdevs);
     };
 
@@ -477,7 +477,7 @@ int MainCmds::demoplay(int argc, const char* const* argv) {
           PlayUtils::getSearchFactor(searchFactorWhenWinningThreshold,searchFactorWhenWinning,params,recentWinLossValues,P_BLACK),
           PlayUtils::getSearchFactor(searchFactorWhenWinningThreshold,searchFactorWhenWinning,params,recentWinLossValues,P_WHITE)
         );
-      Loc moveLoc = bot->genMoveSynchronousAnalyze(pla,tc,searchFactor,callbackPeriod,callback);
+      Loc moveLoc = bot->genMoveSynchronousAnalyze(pla,tc,searchFactor,callbackPeriod,&callback);
 
       bool isLegal = bot->isLegalStrict(moveLoc,pla);
       if(moveLoc == Board::NULL_LOC || !isLegal) {

--- a/cpp/search/search.cpp
+++ b/cpp/search/search.cpp
@@ -477,14 +477,14 @@ void Search::runWholeSearch(Logger& logger, std::atomic<bool>& shouldStopNow) {
 }
 
 void Search::runWholeSearch(Logger& logger, std::atomic<bool>& shouldStopNow, bool pondering) {
-  std::atomic<bool> searchBegun(false);
+  std::function<void()>* searchBegun = NULL;
   runWholeSearch(logger,shouldStopNow,searchBegun,pondering,TimeControls(),1.0);
 }
 
 void Search::runWholeSearch(
   Logger& logger,
   std::atomic<bool>& shouldStopNow,
-  std::atomic<bool>& searchBegun,
+  std::function<void()>* searchBegun,
   bool pondering,
   const TimeControls& tc,
   double searchFactor
@@ -531,7 +531,8 @@ void Search::runWholeSearch(
   }
 
   beginSearch(pondering);
-  searchBegun.store(true,std::memory_order_release);
+  if(searchBegun != NULL)
+    (*searchBegun)();
   int64_t numNonPlayoutVisits = getRootVisits();
 
   auto searchLoop = [this,&timer,&numPlayoutsShared,numNonPlayoutVisits,&logger,&shouldStopNow,maxVisits,maxPlayouts,maxTime](int threadIdx) {

--- a/cpp/search/search.h
+++ b/cpp/search/search.h
@@ -33,6 +33,7 @@ struct ReportedSearchValues {
   double lead;
   double winLossValue;
   double utility;
+  int64_t visits;
 
   ReportedSearchValues();
   ~ReportedSearchValues();
@@ -240,7 +241,7 @@ struct Search {
   void runWholeSearch(
     Logger& logger,
     std::atomic<bool>& shouldStopNow,
-    std::atomic<bool>& searchBegun, //will be set to true once search has begun and tree inspection is safe
+    std::function<void()>* searchBegun, //If not null, will be called once search has begun and tree inspection is safe
     bool pondering,
     const TimeControls& tc,
     double searchFactor
@@ -250,7 +251,7 @@ struct Search {
   //All of these functions are safe to call in multithreadedly WHILE the search is ongoing, to print out
   //intermediate states of the search, so long as the search has initialized itself and actually begun.
   //In particular, they are allowed to run concurrently with runWholeSearch, so long as searchBegun has
-  //been flagged true, continuing up until the next call to any other top-level control function above or
+  //been called-back, continuing up until the next call to any other top-level control function above or
   //the next runWholeSearch call.
   //They are NOT safe to call in parallel with any of the other top level-functions besides the search.
 
@@ -288,6 +289,8 @@ struct Search {
 
   //Get the number of visits recorded for the root node
   int64_t getRootVisits() const;
+  //Get the root node's policy prediction
+  bool getPolicy(float policyProbs[NNPos::MAX_NN_POLICY_SIZE]) const;
   //Get the surprisingness (kl-divergence) of the search result given the policy prior.
   double getPolicySurprise() const;
 


### PR DESCRIPTION
Adds `reportDuringSearchEvery` option to analysis engine to allow for ongoing reporting during an analysis.
Adds the ability to prematurely terminate earlier-submitted queries to the analysis engine.

See draft of updated docs here:
https://github.com/lightvector/KataGo/blob/ongoing-analysis/docs/Analysis_Engine.md