### PR TITLE
Fix build on aarch64 and aarch32 systems

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -403,7 +403,7 @@ if(MSVC)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCC)
-  if(NOT (${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm"))
+  if(NOT (${CMAKE_SYSTEM_PROCESSOR} MATCHES "(arm|aarch32|aarch64)"))
     set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -mfpmath=sse")
   endif()
   if(USE_AVX2)


### PR DESCRIPTION
The `CMAKE_SYSTEM_PROCESSOR` cmake variable takes on a few different values for different arm systems, so this patch just adds those values in.

For anyone curious, this was the only modification needed to get KataGo to build on NVidia's Jetson Nano 2G board, which detects as `aarch64`. The device benchmarks at 11.32 visits/s :)