### PR TITLE
Move whiteNoResultProb assignment to match rest of codebase

### DIFF
--- a/cpp/neuralnet/nneval.cpp
+++ b/cpp/neuralnet/nneval.cpp
@@ -440,9 +440,9 @@ void NNEvaluator::serve(
         //These aren't really probabilities. Win/Loss/NoResult will get softmaxed later
         double whiteWinProb = 0.0 + rand.nextGaussian() * 0.20;
         double whiteLossProb = 0.0 + rand.nextGaussian() * 0.20;
+        double whiteNoResultProb = 0.0 + rand.nextGaussian() * 0.20;
         double whiteScoreMean = 0.0 + rand.nextGaussian() * 0.20;
         double whiteScoreMeanSq = 0.0 + rand.nextGaussian() * 0.20;
-        double whiteNoResultProb = 0.0 + rand.nextGaussian() * 0.20;
         double varTimeLeft = 0.5 * boardXSize * boardYSize;
         resultBuf->result->whiteWinProb = (float)whiteWinProb;
         resultBuf->result->whiteLossProb = (float)whiteLossProb;


### PR DESCRIPTION
This assignment seemed to be out of order vs all other parts of the codebase.

Totally unimportant nit I stumbled across.