### PR TITLE
Jp rules patch

### DIFF
--- a/cpp/command/evalsgf.cpp
+++ b/cpp/command/evalsgf.cpp
@@ -156,7 +156,7 @@ int MainCmds::evalsgf(int argc, const char* const* argv) {
     vector<Loc> extraMoveLocs = Location::parseSequence(extraMoves,board);
     for(size_t i = 0; i<extraMoveLocs.size(); i++) {
       Loc loc = extraMoveLocs[i];
-      if(!board.isLegal(loc,nextPla,hist.rules.multiStoneSuicideLegal)) {
+      if(!hist.isLegal(board,loc,nextPla)) {
         cerr << board << endl;
         cerr << "Extra illegal move for " << PlayerIO::colorToChar(nextPla) << ": " << Location::toString(loc,board) << endl;
         throw StringError("Illegal extra move");
@@ -270,7 +270,7 @@ int MainCmds::evalsgf(int argc, const char* const* argv) {
     Player pla = nextPla;
     for(int i = 0; i<options.branch_.size(); i++) {
       Loc loc = options.branch_[i];
-      if(!copy.isLegal(loc,pla,copyHist.rules.multiStoneSuicideLegal)) {
+      if(!copyHist.isLegal(copy,loc,pla)) {
         cerr << board << endl;
         cerr << "Branch Illegal move for " << PlayerIO::colorToChar(pla) << ": " << Location::toString(loc,board) << endl;
         return 1;

--- a/cpp/game/board.cpp
+++ b/cpp/game/board.cpp
@@ -213,6 +213,11 @@ void Board::clearSimpleKoLoc() {
   ko_loc = NULL_LOC;
 }
 
+//Gets the number of stones of the chain at loc. Precondition: location must be black or white.
+int Board::getChainSize(Loc loc) const
+{
+  return chain_data[chain_head[loc]].num_locs;
+}
 
 //Gets the number of liberties of the chain at loc. Assertion: location must be black or white.
 int Board::getNumLiberties(Loc loc) const

--- a/cpp/game/board.h
+++ b/cpp/game/board.h
@@ -153,6 +153,8 @@ struct Board
 
   //Functions------------------------------------
 
+  //Gets the number of stones of the chain at loc. Precondition: location must be black or white.
+  int getChainSize(Loc loc) const;
   //Gets the number of liberties of the chain at loc. Precondition: location must be black or white.
   int getNumLiberties(Loc loc) const;
   //Returns the number of liberties a new stone placed here would have, or max if it would be >= max.

--- a/cpp/game/boardhistory.h
+++ b/cpp/game/boardhistory.h
@@ -135,11 +135,12 @@ struct BoardHistory {
   //preventEncore artifically prevents any move from entering or advancing the encore phase when using territory scoring.
   void makeBoardMoveAssumeLegal(Board& board, Loc moveLoc, Player movePla, const KoHashTable* rootKoHashTable);
   void makeBoardMoveAssumeLegal(Board& board, Loc moveLoc, Player movePla, const KoHashTable* rootKoHashTable, bool preventEncore);
-  //Make a move with legality checking, but be extremely tolerant and allow moves that can still be handled but that may not technically
+  //Make a move with legality checking, but be mostly tolerant and allow moves that can still be handled but that may not technically
   //be legal. This is intended for reading moves from SGFs and such where maybe we're getting moves that were played in a different
   //ruleset than ours. Returns true if successful, false if was illegal even unter tolerant rules.
   bool makeBoardMoveTolerant(Board& board, Loc moveLoc, Player movePla);
   bool makeBoardMoveTolerant(Board& board, Loc moveLoc, Player movePla, bool preventEncore);
+  bool isLegalTolerant(const Board& board, Loc moveLoc, Player movePla) const;
 
   //Slightly expensive, check if the entire game is all pass-alive-territory, and if so, declare the game finished
   void endGameIfAllPassAlive(const Board& board);

--- a/cpp/search/search.cpp
+++ b/cpp/search/search.cpp
@@ -299,15 +299,7 @@ bool Search::isLegalTolerant(Loc moveLoc, Player movePla) const {
     return copy.isLegal(moveLoc,movePla,multiStoneSuicideLegal);
   }
   else {
-    //Don't require that the move is legal for the history, merely the board, so that
-    //we're robust to GTP or an sgf file saying that a move was made that violates superko or things like that.
-    //In the encore, we also need to ignore the simple ko loc, since the board itself will report a move as illegal
-    //when actually it is a legal pass-for-ko.
-    if(!rootBoard.isLegalIgnoringKo(moveLoc,rootPla,multiStoneSuicideLegal))
-      return false;
-    if(rootHistory.encorePhase <= 0 && rootBoard.isKoBanned(moveLoc))
-      return false;
-    return true;
+    return rootHistory.isLegalTolerant(rootBoard,moveLoc,movePla);
   }
 }
 

--- a/cpp/search/search.h
+++ b/cpp/search/search.h
@@ -237,6 +237,8 @@ struct Search {
   //In the case where the player was not the expected one moving next, also clears history.
   bool makeMove(Loc moveLoc, Player movePla);
   bool makeMove(Loc moveLoc, Player movePla, bool preventEncore);
+
+  //isLegalTolerant also specially handles players moving multiple times in a row.
   bool isLegalTolerant(Loc moveLoc, Player movePla) const;
   bool isLegalStrict(Loc moveLoc, Player movePla) const;
 

--- a/cpp/tests/results/runOutputTests.txt
+++ b/cpp/tests/results/runOutputTests.txt
@@ -5397,7 +5397,7 @@ NN Inputs V3V4V6 Ko Prohib and pass hist and whitebonus and encorestart
 -----------------------------------------------------------------
 VERSION 3
 Move 24
-010100 001010 111000 001001 001110 010111 
+010100 001010 111000 001001 001110 110111 
 Pass Hist Channels: 0 0 1 0 0 
 Selfkomi channel times 15: -0.5
 EncorePhase channel 10,11: 1 0
@@ -5435,7 +5435,7 @@ Channel: 21
 0 0 0 0 0 0  X1. X . . .
 
 Move 25
-010101 001000 111010 001000 001110 010111 
+110101 001010 111010 001000 001110 010111 
 Pass Hist Channels: 0 0 0 1 0 
 Selfkomi channel times 15: 1.5
 EncorePhase channel 10,11: 1 0
@@ -5473,7 +5473,7 @@ Channel: 21
 0 0 0 0 0 0  X . X . . .
 
 Move 26
-010101 001000 111010 001001 001110 010111 
+010101 001000 111010 001001 001110 110111 
 Pass Hist Channels: 1 0 0 0 1 
 Selfkomi channel times 15: -1.5
 EncorePhase channel 10,11: 1 0
@@ -5511,7 +5511,7 @@ Channel: 21
 0 0 0 0 0 0  X . X . . .
 
 Move 30
-010100 001010 011000 001001 001110 000111 
+010100 001010 011010 001001 001110 000111 
 Pass Hist Channels: 0 0 0 1 1 
 Selfkomi channel times 15: -1.5
 EncorePhase channel 10,11: 1 1
@@ -5549,7 +5549,7 @@ Channel: 21
 1 0 1 0 0 0  . O4X . . .
 
 Move 31
-010101 001010 011000 001001 001110 100111 
+010101 001010 011000 001001 001110 110111 
 Pass Hist Channels: 0 0 0 0 1 
 Selfkomi channel times 15: 1.5
 EncorePhase channel 10,11: 1 1
@@ -5625,7 +5625,7 @@ Channel: 21
 1 0 1 0 0 0  X5.2X . . .
 
 Move 33
-010101 001000 011010 101000 101110 010111 
+010101 001010 011010 101000 101110 010111 
 Pass Hist Channels: 0 0 0 0 0 
 Selfkomi channel times 15: 1.5
 EncorePhase channel 10,11: 1 1
@@ -5665,7 +5665,7 @@ Channel: 21
 
 VERSION 4
 Move 24
-010100 001010 111000 001001 001110 010111 
+010100 001010 111000 001001 001110 110111 
 Pass Hist Channels: 0 0 1 0 0 
 Selfkomi channel times 15: -0.5
 EncorePhase channel 10,11: 1 0
@@ -5703,7 +5703,7 @@ Channel: 21
 0 0 0 0 0 0  X1. X . . .
 
 Move 25
-010101 001000 111010 001000 001110 010111 
+110101 001010 111010 001000 001110 010111 
 Pass Hist Channels: 0 0 0 1 0 
 Selfkomi channel times 15: 1.5
 EncorePhase channel 10,11: 1 0
@@ -5741,7 +5741,7 @@ Channel: 21
 0 0 0 0 0 0  X . X . . .
 
 Move 26
-010101 001000 111010 001001 001110 010111 
+010101 001000 111010 001001 001110 110111 
 Pass Hist Channels: 1 0 0 0 1 
 Selfkomi channel times 15: -1.5
 EncorePhase channel 10,11: 1 0
@@ -5779,7 +5779,7 @@ Channel: 21
 0 0 0 0 0 0  X . X . . .
 
 Move 30
-010100 001010 011000 001001 001110 000111 
+010100 001010 011010 001001 001110 000111 
 Pass Hist Channels: 0 0 0 1 1 
 Selfkomi channel times 15: -1.5
 EncorePhase channel 10,11: 1 1
@@ -5817,7 +5817,7 @@ Channel: 21
 1 0 1 0 0 0  . O4X . . .
 
 Move 31
-010101 001010 011000 001001 001110 100111 
+010101 001010 011000 001001 001110 110111 
 Pass Hist Channels: 0 0 0 0 1 
 Selfkomi channel times 15: 1.5
 EncorePhase channel 10,11: 1 1
@@ -5893,7 +5893,7 @@ Channel: 21
 1 0 1 0 0 0  X5.2X . . .
 
 Move 33
-010101 001000 011010 101000 101110 010111 
+010101 001010 011010 101000 101110 010111 
 Pass Hist Channels: 0 0 0 0 0 
 Selfkomi channel times 15: 1.5
 EncorePhase channel 10,11: 1 1
@@ -5933,7 +5933,7 @@ Channel: 21
 
 VERSION 6
 Move 24
-010100 001010 111000 001001 001110 010111 
+010100 001010 111000 001001 001110 110111 
 Pass Hist Channels: 0 0 1 0 0 
 Selfkomi channel times 15: -0.375
 EncorePhase channel 12,13: 1 0
@@ -5971,7 +5971,7 @@ Channel: 21
 0 0 0 0 0 0  X1. X . . .
 
 Move 25
-010101 001000 111010 001000 001110 010111 
+110101 001010 111010 001000 001110 010111 
 Pass Hist Channels: 0 0 0 1 0 
 Selfkomi channel times 15: 1.125
 EncorePhase channel 12,13: 1 0
@@ -6009,7 +6009,7 @@ Channel: 21
 0 0 0 0 0 0  X . X . . .
 
 Move 26
-010101 001000 111010 001001 001110 010111 
+010101 001000 111010 001001 001110 110111 
 Pass Hist Channels: 1 0 0 0 1 
 Selfkomi channel times 15: -1.125
 EncorePhase channel 12,13: 1 0
@@ -6047,7 +6047,7 @@ Channel: 21
 0 0 0 0 0 0  X . X . . .
 
 Move 30
-010100 001010 011000 001001 001110 000111 
+010100 001010 011010 001001 001110 000111 
 Pass Hist Channels: 0 0 0 0 0 
 Selfkomi channel times 15: -1.125
 EncorePhase channel 12,13: 1 1
@@ -6085,7 +6085,7 @@ Channel: 21
 1 0 1 0 0 0  . O4X . . .
 
 Move 31
-010101 001010 011000 001001 001110 100111 
+010101 001010 011000 001001 001110 110111 
 Pass Hist Channels: 0 0 0 0 0 
 Selfkomi channel times 15: 1.125
 EncorePhase channel 12,13: 1 1
@@ -6161,7 +6161,7 @@ Channel: 21
 1 0 1 0 0 0  X5.2X . . .
 
 Move 33
-010101 001000 011010 101000 101110 010111 
+010101 001010 011010 101000 101110 010111 
 Pass Hist Channels: 0 0 0 0 0 
 Selfkomi channel times 15: 1.125
 EncorePhase channel 12,13: 1 1
@@ -6201,7 +6201,7 @@ Channel: 21
 
 VERSION 7
 Move 24
-010100 001010 111000 001001 001110 010111 
+010100 001010 111000 001001 001110 110111 
 Pass Hist Channels: 0 0 1 0 0 
 Selfkomi channel times 15: -0.375
 EncorePhase channel 12,13: 1 0
@@ -6239,7 +6239,7 @@ Channel: 21
 0 0 0 0 0 0  X1. X . . .
 
 Move 25
-010101 001000 111010 001000 001110 010111 
+110101 001010 111010 001000 001110 010111 
 Pass Hist Channels: 0 0 0 1 0 
 Selfkomi channel times 15: 1.125
 EncorePhase channel 12,13: 1 0
@@ -6277,7 +6277,7 @@ Channel: 21
 0 0 0 0 0 0  X . X . . .
 
 Move 26
-010101 001000 111010 001001 001110 010111 
+010101 001000 111010 001001 001110 110111 
 Pass Hist Channels: 1 0 0 0 1 
 Selfkomi channel times 15: -1.125
 EncorePhase channel 12,13: 1 0
@@ -6315,7 +6315,7 @@ Channel: 21
 0 0 0 0 0 0  X . X . . .
 
 Move 30
-010100 001010 011000 001001 001110 000111 
+010100 001010 011010 001001 001110 000111 
 Pass Hist Channels: 0 0 0 0 0 
 Selfkomi channel times 15: -1.125
 EncorePhase channel 12,13: 1 1
@@ -6353,7 +6353,7 @@ Channel: 21
 1 0 1 0 0 0  . O4X . . .
 
 Move 31
-010101 001010 011000 001001 001110 100111 
+010101 001010 011000 001001 001110 110111 
 Pass Hist Channels: 0 0 0 0 0 
 Selfkomi channel times 15: 1.125
 EncorePhase channel 12,13: 1 1
@@ -6429,7 +6429,7 @@ Channel: 21
 1 0 1 0 0 0  X5.2X . . .
 
 Move 33
-010101 001000 011010 101000 101110 010111 
+010101 001010 011010 101000 101110 010111 
 Pass Hist Channels: 0 0 0 0 0 
 Selfkomi channel times 15: 1.125
 EncorePhase channel 12,13: 1 1
@@ -14780,10 +14780,10 @@ Has button 0
 Presumed next pla White
 Past normal phase end 0
 Game result 1 White 7.5 1 0 0
-Last moves B1 F1 E1 pass pass pass H1 C1 G1 pass J1 pass D1 pass C1 F1 pass H1 G1 F1 pass pass A1 pass pass 
+Last moves B1 F1 E1 pass pass pass H1 C1 G1 pass J1 pass D1 pass C1 F1 pass H1 G1 G1 pass pass A1 pass pass 
 Num captured black stones 3
 Num captured white stones 3
-(;FF[4]GM[1]SZ[9:1]PB[Black]PW[White]HA[0]KM[7.5]RU[koSIMPLEscoreTERRITORYtaxSEKIsui0]RE[W+7.5]C[startTurnIdx=1,initTurnNum=0,gameHash=4ABB4DB214CD9C8328941CCEF8590F0D,gtype=normal];B[ba];W[fa]C[0.44 0.26 0.30 1.4 v=2 weight=1.00];B[ea]C[0.45 0.28 0.28 -1.0 v=2 weight=1.00];W[]C[0.39 0.33 0.27 1.0 v=2 weight=1.00];B[]C[0.32 0.39 0.29 0.5 v=2 weight=1.00];W[]C[0.29 0.39 0.32 0.4 v=2 weight=1.00];B[ha]C[0.32 0.39 0.28 2.7 v=2 weight=1.00];W[ca]C[0.35 0.39 0.26 1.9 v=2 weight=1.00];B[ga]C[0.36 0.35 0.29 1.6 v=2 weight=1.00];W[]C[0.35 0.38 0.28 1.5 v=2 weight=1.00];B[ia]C[0.30 0.34 0.36 -0.2 v=2 weight=1.00];W[]C[0.32 0.32 0.36 -2.1 v=2 weight=1.00];B[da]C[0.32 0.32 0.36 -1.1 v=2 weight=1.00];W[]C[0.30 0.34 0.36 -0.4 v=2 weight=1.00];B[ca]C[0.32 0.34 0.34 -1.3 v=2 weight=1.00];W[fa]C[0.38 0.28 0.34 0.1 v=2 weight=1.00];B[]C[0.40 0.31 0.29 -0.5 v=2 weight=1.00];W[ha]C[0.41 0.34 0.25 -0.6 v=2 weight=1.00];B[ga]C[0.43 0.31 0.26 0.6 v=2 weight=1.00];W[]TR[fa]C[Pass for ko 0.37 0.29 0.34 0.8 v=2 weight=1.00];B[]C[0.32 0.30 0.38 -0.0 v=2 weight=1.00];W[]C[0.33 0.30 0.37 -1.9 v=2 weight=1.00];B[aa]C[0.31 0.33 0.35 -3.2 v=2 weight=1.00];W[]C[0.34 0.33 0.32 -0.8 v=2 weight=1.00];B[]C[0.70 0.16 0.14 4.4 v=2 weight=1.00 result=W+7.5])
+(;FF[4]GM[1]SZ[9:1]PB[Black]PW[White]HA[0]KM[7.5]RU[koSIMPLEscoreTERRITORYtaxSEKIsui0]RE[W+7.5]C[startTurnIdx=1,initTurnNum=0,gameHash=4ABB4DB214CD9C8328941CCEF8590F0D,gtype=normal];B[ba];W[fa]C[0.44 0.26 0.30 1.4 v=2 weight=1.00];B[ea]C[0.45 0.28 0.28 -1.0 v=2 weight=1.00];W[]C[0.39 0.33 0.27 1.0 v=2 weight=1.00];B[]C[0.32 0.39 0.29 0.5 v=2 weight=1.00];W[]C[0.29 0.39 0.32 0.4 v=2 weight=1.00];B[ha]C[0.32 0.39 0.28 2.7 v=2 weight=1.00];W[ca]C[0.35 0.39 0.26 1.9 v=2 weight=1.00];B[ga]C[0.36 0.35 0.29 1.6 v=2 weight=1.00];W[]C[0.35 0.38 0.28 1.5 v=2 weight=1.00];B[ia]C[0.30 0.34 0.36 -0.2 v=2 weight=1.00];W[]C[0.32 0.32 0.36 -2.1 v=2 weight=1.00];B[da]C[0.32 0.32 0.36 -1.1 v=2 weight=1.00];W[]C[0.30 0.34 0.36 -0.4 v=2 weight=1.00];B[ca]C[0.32 0.34 0.34 -1.3 v=2 weight=1.00];W[fa]C[0.38 0.28 0.34 0.1 v=2 weight=1.00];B[]C[0.40 0.31 0.29 -0.5 v=2 weight=1.00];W[ha]C[0.41 0.34 0.25 -0.6 v=2 weight=1.00];B[ga]C[0.43 0.31 0.26 0.6 v=2 weight=1.00];W[]TR[ga]C[Pass for ko 0.37 0.29 0.34 0.8 v=2 weight=1.00];B[]C[0.32 0.30 0.38 -0.0 v=2 weight=1.00];W[]C[0.33 0.30 0.37 -1.9 v=2 weight=1.00];B[aa]C[0.31 0.33 0.35 -3.2 v=2 weight=1.00];W[]C[0.34 0.33 0.32 -0.8 v=2 weight=1.00];B[]C[0.70 0.16 0.14 4.4 v=2 weight=1.00 result=W+7.5])
 ===================================================================
 Unlimited time controls
 ===================================================================

--- a/cpp/tests/testrules.cpp
+++ b/cpp/tests/testrules.cpp
@@ -29,6 +29,8 @@ static void makeMoveAssertLegal(BoardHistory& hist, Board& board, Loc loc, Playe
 
   if(!hist.isLegal(board, loc, pla))
     throw StringError("Illegal move on line " + Global::intToString(line));
+  if(!hist.isLegalTolerant(board, loc, pla))
+    throw StringError("Tolerant illegal move on line " + Global::intToString(line));
   hist.makeBoardMoveAssumeLegal(board, loc, pla, table, preventEncore);
   checkKoHashConsistency(hist,board,getOpp(pla));
 
@@ -2837,13 +2839,13 @@ isResignation: 0
 4 .X..OX. NPO PS0 E1  0000000 0000000
 3 .X.OOX. NPX PS0 E1  0000000 0000000
 3 XX.OOX. NPO PS0 E1  0000000 0000000
-2 XX.OO.O NPX PS0 E1  0000001 0000000
+3 XX.OO.O NPX PS0 E1  0000001 0000000
 3 XX.OO.O NPO PS0 E1  0000000 0000000
 4 ..OOO.O NPX PS0 E1  0000000 0000000
 2 .XOOO.O NPO PS0 E1  0000000 0000000
-3 O.OOO.O NPX PS0 E1  1000000 0000000
-3 O.OOO.O NPO PS0 E1  0000000 0000000
-2 OOOOO.O NPX PS0 E1  0000000 0000000
+4 O.OOO.O NPX PS0 E1  1000000 0000000
+3 O.OOO.O NPO PS1 E1  1000000 0000000
+2 OOOOO.O NPX PS0 E1  1000000 0000000
 6 .....X. NPO PS0 E1  0000000 0000000
 5 ....OX. NPX PS0 E1  0000000 0000000
 5 X...OX. NPO PS0 E1  0000000 0000000
@@ -2862,62 +2864,106 @@ isResignation: 0
 3 .O..OX. NPX PS0 E1  0000000 0000000
 3 .OX.OX. NPO PS0 E1  0000000 0000000
 3 .OX.OX. NPX PS1 E1  0000000 0000000
-3 X.X.OX. NPO PS0 E1  1000000 0000000
-4 X.X.O.O NPX PS0 E1  1000001 0000000
-2 X.XXO.O NPO PS0 E1  1000001 0000000
-4 .O..O.O NPX PS0 E1  0000001 0000000
-3 .O.XO.O NPO PS0 E1  0000001 0000000
-2 .OO.O.O NPX PS0 E1  0000001 0000000
-4 .OO.O.O NPO PS0 E1  0000000 0000000
-2 .OOOO.O NPX PS0 E1  0000000 0000000
-2 .OOOOX. NPO PS0 E1  0000010 0000000
+4 X.X.OX. NPO PS0 E1  1000000 0000000
+3 X.X.OX. NPX PS0 E1  0000000 0000000
+3 XXX.OX. NPO PS0 E1  0000000 0000000
+4 ...OOX. NPX PS0 E1  0000000 0000000
+4 X..OOX. NPO PS0 E1  0000000 0000000
+2 X.OOOX. NPX PS0 E1  0000000 0000000
+4 XX...X. NPO PS0 E1  0000000 0000000
+3 XX.O.X. NPX PS0 E1  0000000 0000000
+3 XX.OXX. NPO PS0 E1  0000000 0000000
+3 ..OOXX. NPX PS0 E1  0000000 0000000
+3 X.OOXX. NPO PS0 E1  0000000 0000000
+2 .OOOXX. NPX PS0 E1  0000000 0000000
+2 .OOOXX. NPO PS1 E1  0000000 0000000
+3 .OOO..O NPX PS0 E1  0000000 0000000
+3 .OOO.X. NPO PS0 E1  0000000 0000000
 2 .OOOOX. NPX PS0 E1  0000000 0000000
 5 X....X. NPO PS0 E1  0000000 0000000
-5 X..O.X. NPX PS0 E1  0000000 0000000
-3 XX.O.X. NPO PS0 E1  0000000 0000000
-5 ..OO.X. NPX PS0 E1  0000000 0000000
-2 .XOO.X. NPO PS0 E1  0000000 0000000
-3 .XOO.X. NPX PS1 E1  0000000 0000000
-3 .X..XX. NPO PS0 E1  0000000 0000000
-3 .X.OXX. NPX PS0 E1  0000000 0000000
-1 .XX.XX. NPO PS0 E1  0000000 0000000
-4 .XX.XX. NPX PS1 E1  0000000 0000000
+4 X...OX. NPX PS0 E1  0000000 0000000
+5 X...OX. NPO PS1 E1  0000000 0000000
+3 .O..OX. NPX PS0 E1  0000000 0000000
+5 .O..OX. NPO PS1 E1  0000000 0000000
+3 OO..OX. NPX PS0 E1  0000000 0000000
+4 ..X.OX. NPO PS0 E1  0000000 0000000
+6 ..X.O.O NPX PS0 E1  0000001 0000000
+5 ..X.O.O NPO PS0 E1  0000000 0000000
+4 ..X.OOO NPX PS0 E1  0000000 0000000
+6 ..XX... NPO PS0 E1  0000000 0000000
+5 O.XX... NPX PS0 E1  0000000 0000000
+4 .XXX... NPO PS0 E1  0000000 0000000
+3 .XXXO.. NPX PS0 E1  0000000 0000000
+1 .XXX.X. NPO PS0 E1  0000000 0000000
+4 .XXX.X. NPX PS1 E1  0000000 0000000
 1 .XXXXX. NPO PS0 E1  0000000 0000000
 3 .XXXXX. NPX PS1 E1  0000000 0000000
-2 XXXXXX. NPO PS0 E1  0000000 0000000
-7 ......O NPX PS0 E1  0000000 0000000
-6 ...X..O NPO PS0 E1  0000000 0000000
-5 O..X..O NPX PS0 E1  0000000 0000000
-3 .X.X..O NPO PS0 E1  0000000 0000000
-4 .X.XO.O NPX PS0 E1  0000000 0000000
-1 .X.X.X. NPO PS0 E1  0000000 0000000
-5 .X.X.X. NPX PS1 E1  0000000 0000000
-2 XX.X.X. NPO PS0 E1  0000000 0000000
-5 ..OX.X. NPX PS0 E1  0000000 0000000
-3 X.OX.X. NPO PS0 E1  0000000 0000000
-4 .OOX.X. NPX PS0 E1  0000000 0000000
-2 .OOXXX. NPO PS0 E1  0000000 0000000
-2 .OOXXX. NPX PS1 E1  0000000 0000000
-3 X..XXX. NPO PS0 E1  0000000 0000000
-3 .O.XXX. NPX PS0 E1  0000000 0000000
-3 .O.XXXX NPO PS0 E1  0000000 0000000
-2 OO.XXXX NPX PS0 E1  0000000 0000000
-3 ..XXXXX NPO PS0 E1  0000000 0000000
-2 O.XXXXX NPX PS0 E1  0000000 0000000
 2 .XXXXXX NPO PS0 E1  0000000 0000000
 1 .XXXXXX NPX PS1 E1  0000000 0000000
 2 .XXXXXX NPO PS0 E2  0000000 0111111
 7 O...... NPX PS0 E2  0000000 0111111
-6 O...X.. NPO PS0 E2  0000000 0111111
-5 O.O.X.. NPX PS0 E2  0000000 0111111
-4 O.O.X.X NPO PS0 E2  0000000 0111111
-3 OOO.X.X NPX PS0 E2  0000000 0111111
-2 OOO.XXX NPO PS0 E2  0000000 0111111
-2 OOO.XXX NPX PS1 E2  0000000 0111111
-2 OOO.XXX NPO PS2 E2  0000000 0111111
-White bonus score 3
-Winner: White
-W-B Score: 0.5
+6 O.....X NPO PS0 E2  0000000 0111111
+4 O...O.X NPX PS0 E2  0000000 0111111
+3 O.X.O.X NPO PS0 E2  0000000 0111111
+3 O.XOO.X NPX PS0 E2  0000000 0111111
+3 O.X..XX NPO PS0 E2  0000000 0111111
+5 O.X.O.. NPX PS0 E2  0000000 0111111
+3 O.X.O.X NPO PS0 E2  0000000 0111111
+3 O.X.OO. NPX PS0 E2  0000000 0111111
+3 .XX.OO. NPO PS0 E2  0000000 0111111
+3 .XX.OOO NPX PS0 E2  0000000 0111111
+4 .XXX... NPO PS0 E2  0000000 0111111
+3 .XXX.O. NPX PS0 E2  0000000 0111111
+3 .XXX.O. NPO PS1 E2  0000000 0111111
+2 .XXXOO. NPX PS0 E2  0000000 0111111
+2 .XXXOO. NPO PS1 E2  0000000 0111111
+4 O...OO. NPX PS0 E2  0000000 0111111
+4 .X..OO. NPO PS0 E2  0000000 0111111
+4 .X..OOO NPX PS0 E2  0000000 0111111
+3 XX..OOO NPO PS0 E2  0000000 0111111
+3 XX..OOO NPX PS1 E2  0000000 0111111
+5 XX.X... NPO PS0 E2  0000000 0111111
+3 XX.XO.. NPX PS0 E2  0000000 0111111
+2 XX.X.X. NPO PS0 E2  0000000 0111111
+5 ..OX.X. NPX PS0 E2  0000000 0111111
+1 .X.X.X. NPO PS0 E2  0000000 0111111
+5 .X.X.X. NPX PS1 E2  0000000 0111111
+1 .X.XXX. NPO PS0 E2  0000000 0111111
+4 .X.XXX. NPX PS1 E2  0000000 0111111
+2 XX.XXX. NPO PS0 E2  0000000 0111111
+3 ..OXXX. NPX PS0 E2  0000000 0111111
+4 ..OXXX. NPO PS1 E2  0000000 0111111
+6 ..O...O NPX PS0 E2  0000000 0111111
+5 X.O...O NPO PS0 E2  0000000 0111111
+2 X.O.O.O NPX PS0 E2  0000000 0111111
+5 X.O.OX. NPO PS0 E2  0000010 0111111
+2 X.O.OX. NPX PS0 E2  0000000 0111111
+4 X.OX.X. NPO PS0 E2  0001000 0111111
+4 X.OX.X. NPX PS0 E2  0000000 0111111
+2 XX.X.X. NPO PS0 E2  0000000 0111111
+4 XX.X.X. NPX PS1 E2  0000000 0111111
+3 XX.X.XX NPO PS0 E2  0000000 0111111
+3 XX.XO.. NPX PS0 E2  0000000 0111111
+3 XX.XO.X NPO PS0 E2  0000000 0111111
+2 XX.XOO. NPX PS0 E2  0000000 0111111
+2 XX.XOO. NPO PS1 E2  0000000 0111111
+3 ..O.OO. NPX PS0 E2  0000000 0111111
+5 ..O.OO. NPO PS1 E2  0000000 0111111
+3 ..OOOO. NPX PS0 E2  0000000 0111111
+2 .XOOOO. NPO PS0 E2  0000000 0111111
+3 O.OOOO. NPX PS0 E2  1000000 0111111
+3 O.OOOO. NPO PS1 E2  1000000 0111111
+2 OOOOOO. NPX PS0 E2  1000000 0111111
+7 ......X NPO PS0 E2  0000000 0111111
+5 .O....X NPX PS0 E2  0000000 0111111
+5 .O..X.X NPO PS0 E2  0000000 0111111
+3 .OO.X.X NPX PS0 E2  0000000 0111111
+2 .OOXX.X NPO PS0 E2  0000000 0111111
+2 .OOXX.X NPX PS1 E2  0000000 0111111
+2 .OOXX.X NPO PS2 E2  0000000 0111111
+White bonus score -3
+Winner: Black
+W-B Score: -5.5
 isNoResult: 0
 isResignation: 0
 
@@ -2950,23 +2996,26 @@ isResignation: 0
 4 ...X NPO PS0 E1  0000 0000
 3 O..X NPX PS0 E1  0000 0000
 2 .X.X NPO PS0 E1  0000 0000
-2 .XO. NPX PS0 E1  0010 0000
+3 .XO. NPX PS0 E1  0010 0000
 2 .XO. NPO PS0 E1  0000 0000
 2 .XO. NPX PS1 E1  0000 0000
 2 .XO. NPO PS0 E2  0000 0120
-2 O.O. NPX PS0 E2  1000 0120
-3 O.O. NPO PS1 E2  1000 0120
-2 O.OO NPX PS0 E2  1000 0120
-3 .X.. NPO PS0 E2  0000 0120
-2 .XO. NPX PS0 E2  0000 0120
-2 .X.X NPO PS0 E2  0001 0120
-3 .X.X NPX PS1 E2  0001 0120
-2 XX.X NPO PS0 E2  0001 0120
-1 XX.X NPX PS1 E2  0001 0120
-2 XX.X NPO PS2 E2  0001 0120
+3 O.O. NPX PS0 E2  1000 0120
+3 O.O. NPO PS0 E2  0000 0120
+2 OOO. NPX PS0 E2  0000 0120
+4 ...X NPO PS0 E2  0000 0120
+3 ..O. NPX PS0 E2  0000 0120
+3 X.O. NPO PS0 E2  0000 0120
+2 X.OO NPX PS0 E2  0000 0120
+3 XX.. NPO PS0 E2  0000 0120
+3 ..O. NPX PS0 E2  0000 0120
+3 X.O. NPO PS0 E2  0000 0120
+1 .OO. NPX PS0 E2  0000 0120
+3 .OO. NPO PS1 E2  0000 0120
+1 .OO. NPX PS2 E2  0000 0120
 White bonus score 0
-Winner: Black
-W-B Score: -0.5
+Winner: White
+W-B Score: 4.5
 isNoResult: 0
 isResignation: 0
 
@@ -2996,7 +3045,7 @@ isResignation: 0
 3 .O.. NPX PS0 E1  0000 0000
 2 .OX. NPO PS0 E1  0000 0000
 2 .OX. NPX PS1 E1  0000 0000
-2 X.X. NPO PS0 E1  1000 0000
+3 X.X. NPO PS0 E1  1000 0000
 3 X.X. NPX PS0 E1  0000 0000
 2 X.XX NPO PS0 E1  0000 0000
 1 X.XX NPX PS1 E1  0000 0000
@@ -3148,18 +3197,21 @@ isResignation: 0
 4 XX..X.X NPO PS0 E0  0000000 0000000
 4 XX..X.X NPX PS1 E0  0000000 0000000
 4 XX..X.X NPO PS0 E1  0000000 0000000
-4 XX..XO. NPX PS0 E1  0000010 0000000
+5 XX..XO. NPX PS0 E1  0000010 0000000
 2 XXX.XO. NPO PS0 E1  0000010 0000000
-2 XXX.XO. NPX PS1 E1  0000010 0000000
-2 XXX.XO. NPO PS0 E2  0000000 1110120
-4 ...O.O. NPX PS0 E2  0000000 1110120
-5 ..XO.O. NPO PS0 E2  0000000 1110120
-4 ..XO.OO NPX PS0 E2  0000000 1110120
-3 ..XO.OO NPO PS1 E2  0000000 1110120
-4 ..XO.OO NPX PS2 E2  0000000 1110120
-White bonus score 1
+3 XXX.XO. NPX PS1 E1  0000010 0000000
+2 XXX.XO. NPO PS0 E1  0000000 0000000
+4 ...O.O. NPX PS0 E1  0000000 0000000
+5 ..XO.O. NPO PS0 E1  0000000 0000000
+4 ..XO.OO NPX PS0 E1  0000000 0000000
+3 ..XO.OO NPO PS1 E1  0000000 0000000
+4 ..XO.OO NPX PS0 E2  0000000 0012022
+2 .XXO.OO NPO PS0 E2  0000000 0012022
+2 .XXO.OO NPX PS1 E2  0000000 0012022
+2 .XXO.OO NPO PS2 E2  0000000 0012022
+White bonus score 0
 Winner: White
-W-B Score: 1.5
+W-B Score: 2.5
 isNoResult: 0
 isResignation: 0
 
@@ -3613,6 +3665,1520 @@ xoxx.
     out << endl;
     string expected = R"%%(
 Illegal: (4,3) X
+)%%";
+    expect(name,out,expected);
+  }
+
+  {
+    const char* name = "Double ko death 1a";
+
+    Board board = Board::parseBoard(9,9,R"%%(
+   A B C D E F G H J
+ 9 . . . . X O X . X
+ 8 . . . . X O O X X
+ 7 . . X . X X O X O
+ 6 . . . . O X O O .
+ 5 . . . O O X X O O
+ 4 . X X X X . X O .
+ 3 X X O O O X X O O
+ 2 O O O X O O X X X
+ 1 . . . . . O O O O
+)%%");
+    Rules rules;
+    rules.koRule = Rules::KO_SITUATIONAL;
+    rules.scoringRule = Rules::SCORING_TERRITORY;
+    rules.taxRule = Rules::TAX_NONE;
+    rules.multiStoneSuicideLegal = false;
+    rules.komi = 6.5f;
+    rules.hasButton = false;
+    BoardHistory hist(board,P_WHITE,rules,0);
+
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_WHITE, __LINE__);
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_BLACK, __LINE__);
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_WHITE, __LINE__);
+    makeMoveAssertLegal(hist, board, Location::getLoc(8,3,board.x_size), P_BLACK, __LINE__);
+    makeMoveAssertLegal(hist, board, Location::getLoc(7,0,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(7,0,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(8,3,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    testAssert(!hist.isGameFinished);
+    hist.printDebugInfo(out,board);
+    out << endl;
+    string expected = R"%%(
+HASH: 6CC6F6B94B2F52DED5CA2B28C2D58357
+   A B C D E F G H J
+ 9 . . . . X O . O X
+ 8 . . . . X O O X X
+ 7 . . X . X X O X .
+ 6 . . . . O X O O X
+ 5 . . . O O X X O O
+ 4 . X X X X . X O .
+ 3 X X O O O X X O O
+ 2 O O O X O O X X X
+ 1 . . . . . O O O O
+
+
+Ko recap blocked at H9
+Ko recap blocked at J6
+HASH: 6CC6F6B94B2F52DED5CA2B28C2D58357
+   A B C D E F G H J
+ 9 . . . . X O . O X
+ 8 . . . . X O O X X
+ 7 . . X . X X O X .
+ 6 . . . . O X O O X
+ 5 . . . O O X X O O
+ 4 . X X X X . X O .
+ 3 X X O O O X X O O
+ 2 O O O X O O X X X
+ 1 . . . . . O O O O
+
+
+Ko recap blocked at J6
+HASH: 6CC6F6B94B2F52DED5CA2B28C2D58357
+   A B C D E F G H J
+ 9 . . . . X O . O X
+ 8 . . . . X O O X X
+ 7 . . X . X X O X .
+ 6 . . . . O X O O X
+ 5 . . . O O X X O O
+ 4 . X X X X . X O .
+ 3 X X O O O X X O O
+ 2 O O O X O O X X X
+ 1 . . . . . O O O O
+
+
+HASH: 6CC6F6B94B2F52DED5CA2B28C2D58357
+   A B C D E F G H J
+ 9 . . . . X O . O X
+ 8 . . . . X O O X X
+ 7 . . X . X X O X .
+ 6 . . . . O X O O X
+ 5 . . . O O X X O O
+ 4 . X X X X . X O .
+ 3 X X O O O X X O O
+ 2 O O O X O O X X X
+ 1 . . . . . O O O O
+
+
+Initial pla White
+Encore phase 1
+Turns this phase 5
+Rules koSITUATIONALscoreTERRITORYtaxNONEsui0komi6.5
+Ko recap block hash 00000000000000000000000000000000
+White bonus score -1
+White handicap bonus score 0
+Has button 0
+Presumed next pla Black
+Past normal phase end 0
+Game result 0 Empty 0 0 0 0
+Last moves pass pass pass J6 H9 H9 J6
+
+)%%";
+    expect(name,out,expected);
+  }
+
+  {
+    const char* name = "Double ko death 1b";
+
+    Board board = Board::parseBoard(9,9,R"%%(
+   A B C D E F G H J
+ 9 . . . . X O X . X
+ 8 . . . . X O O X X
+ 7 . . X . X X O X O
+ 6 . . . . O X O O .
+ 5 . . . O O X X O O
+ 4 . X X X X . X O .
+ 3 X X O O O X X O O
+ 2 O O O X O O X X X
+ 1 . . . . . O O O O
+)%%");
+    Rules rules;
+    rules.koRule = Rules::KO_SITUATIONAL;
+    rules.scoringRule = Rules::SCORING_TERRITORY;
+    rules.taxRule = Rules::TAX_NONE;
+    rules.multiStoneSuicideLegal = false;
+    rules.komi = 6.5f;
+    rules.hasButton = false;
+    BoardHistory hist(board,P_WHITE,rules,0);
+
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_WHITE, __LINE__);
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_BLACK, __LINE__);
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_WHITE, __LINE__);
+    makeMoveAssertLegal(hist, board, Location::getLoc(8,3,board.x_size), P_BLACK, __LINE__);
+    makeMoveAssertLegal(hist, board, Location::getLoc(7,0,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(7,0,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(8,2,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    testAssert(!hist.isGameFinished);
+    hist.printDebugInfo(out,board);
+    out << endl;
+    string expected = R"%%(
+HASH: 6CC6F6B94B2F52DED5CA2B28C2D58357
+   A B C D E F G H J
+ 9 . . . . X O . O X
+ 8 . . . . X O O X X
+ 7 . . X . X X O X .
+ 6 . . . . O X O O X
+ 5 . . . O O X X O O
+ 4 . X X X X . X O .
+ 3 X X O O O X X O O
+ 2 O O O X O O X X X
+ 1 . . . . . O O O O
+
+
+Ko recap blocked at H9
+Ko recap blocked at J6
+HASH: 6CC6F6B94B2F52DED5CA2B28C2D58357
+   A B C D E F G H J
+ 9 . . . . X O . O X
+ 8 . . . . X O O X X
+ 7 . . X . X X O X .
+ 6 . . . . O X O O X
+ 5 . . . O O X X O O
+ 4 . X X X X . X O .
+ 3 X X O O O X X O O
+ 2 O O O X O O X X X
+ 1 . . . . . O O O O
+
+
+Ko recap blocked at J6
+HASH: FDD9D2ACBB4B3A6466BD37C59487F4F7
+   A B C D E F G H J
+ 9 . . . . X O . O .
+ 8 . . . . X O O . .
+ 7 . . X . X X O . O
+ 6 . . . . O X O O .
+ 5 . . . O O X X O O
+ 4 . X X X X . X O .
+ 3 X X O O O X X O O
+ 2 O O O X O O X X X
+ 1 . . . . . O O O O
+
+
+HASH: FDD9D2ACBB4B3A6466BD37C59487F4F7
+   A B C D E F G H J
+ 9 . . . . X O . O .
+ 8 . . . . X O O . .
+ 7 . . X . X X O . O
+ 6 . . . . O X O O .
+ 5 . . . O O X X O O
+ 4 . X X X X . X O .
+ 3 X X O O O X X O O
+ 2 O O O X O O X X X
+ 1 . . . . . O O O O
+
+
+Initial pla White
+Encore phase 1
+Turns this phase 5
+Rules koSITUATIONALscoreTERRITORYtaxNONEsui0komi6.5
+Ko recap block hash 00000000000000000000000000000000
+White bonus score -2
+White handicap bonus score 0
+Has button 0
+Presumed next pla Black
+Past normal phase end 0
+Game result 0 Empty 0 0 0 0
+Last moves pass pass pass J6 H9 H9 J7
+
+)%%";
+    expect(name,out,expected);
+  }
+
+  {
+    const char* name = "Double ko death 1c";
+
+    Board board = Board::parseBoard(9,9,R"%%(
+   A B C D E F G H J
+ 9 . . . . X O X . X
+ 8 . . . . X O O X X
+ 7 . . X . X X O X O
+ 6 . . . . O X O O .
+ 5 . . . O O X X O O
+ 4 . X X X X . X O .
+ 3 X X O O O X X O O
+ 2 O O O X O O X X X
+ 1 . . . . . O O O O
+)%%");
+    Rules rules;
+    rules.koRule = Rules::KO_SITUATIONAL;
+    rules.scoringRule = Rules::SCORING_TERRITORY;
+    rules.taxRule = Rules::TAX_NONE;
+    rules.multiStoneSuicideLegal = false;
+    rules.komi = 6.5f;
+    rules.hasButton = false;
+    BoardHistory hist(board,P_WHITE,rules,0);
+
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_WHITE, __LINE__);
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_BLACK, __LINE__);
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_WHITE, __LINE__);
+    makeMoveAssertLegal(hist, board, Location::getLoc(8,3,board.x_size), P_BLACK, __LINE__);
+    makeMoveAssertLegal(hist, board, Location::getLoc(7,0,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(7,0,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(8,3,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(6,0,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(8,2,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(8,3,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    printIllegalMoves(out,board,hist,P_BLACK);
+
+    out << endl;
+    string expected = R"%%(
+HASH: 6CC6F6B94B2F52DED5CA2B28C2D58357
+   A B C D E F G H J
+ 9 . . . . X O . O X
+ 8 . . . . X O O X X
+ 7 . . X . X X O X .
+ 6 . . . . O X O O X
+ 5 . . . O O X X O O
+ 4 . X X X X . X O .
+ 3 X X O O O X X O O
+ 2 O O O X O O X X X
+ 1 . . . . . O O O O
+
+
+Ko recap blocked at H9
+Ko recap blocked at J6
+HASH: 6CC6F6B94B2F52DED5CA2B28C2D58357
+   A B C D E F G H J
+ 9 . . . . X O . O X
+ 8 . . . . X O O X X
+ 7 . . X . X X O X .
+ 6 . . . . O X O O X
+ 5 . . . O O X X O O
+ 4 . X X X X . X O .
+ 3 X X O O O X X O O
+ 2 O O O X O O X X X
+ 1 . . . . . O O O O
+
+
+Ko recap blocked at J6
+HASH: 6CC6F6B94B2F52DED5CA2B28C2D58357
+   A B C D E F G H J
+ 9 . . . . X O . O X
+ 8 . . . . X O O X X
+ 7 . . X . X X O X .
+ 6 . . . . O X O O X
+ 5 . . . O O X X O O
+ 4 . X X X X . X O .
+ 3 X X O O O X X O O
+ 2 O O O X O O X X X
+ 1 . . . . . O O O O
+
+
+HASH: 7D91609C1321DCFF8FF70F3B78BDC9DB
+   A B C D E F G H J
+ 9 . . . . X O X . X
+ 8 . . . . X O O X X
+ 7 . . X . X X O X .
+ 6 . . . . O X O O X
+ 5 . . . O O X X O O
+ 4 . X X X X . X O .
+ 3 X X O O O X X O O
+ 2 O O O X O O X X X
+ 1 . . . . . O O O O
+
+
+Ko recap blocked at G9
+HASH: 7966CC88C79E3DD83CAD6E7CD3DDD890
+   A B C D E F G H J
+ 9 . . . . X O X . X
+ 8 . . . . X O O X X
+ 7 . . X . X X O X O
+ 6 . . . . O X O O .
+ 5 . . . O O X X O O
+ 4 . X X X X . X O .
+ 3 X X O O O X X O O
+ 2 O O O X O O X X X
+ 1 . . . . . O O O O
+
+
+Ko recap blocked at G9
+Ko recap blocked at J7
+HASH: 7966CC88C79E3DD83CAD6E7CD3DDD890
+   A B C D E F G H J
+ 9 . . . . X O X . X
+ 8 . . . . X O O X X
+ 7 . . X . X X O X O
+ 6 . . . . O X O O .
+ 5 . . . O O X X O O
+ 4 . X X X X . X O .
+ 3 X X O O O X X O O
+ 2 O O O X O O X X X
+ 1 . . . . . O O O O
+
+
+Ko recap blocked at G9
+HASH: 7966CC88C79E3DD83CAD6E7CD3DDD890
+   A B C D E F G H J
+ 9 . . . . X O X . X
+ 8 . . . . X O O X X
+ 7 . . X . X X O X O
+ 6 . . . . O X O O .
+ 5 . . . O O X X O O
+ 4 . X X X X . X O .
+ 3 X X O O O X X O O
+ 2 O O O X O O X X X
+ 1 . . . . . O O O O
+
+
+Ko recap blocked at G9
+Ko-recap-blocked: (6,0)
+Illegal: (8,3) X
+
+)%%";
+    expect(name,out,expected);
+  }
+
+  {
+    const char* name = "Double ko death 2a";
+
+    Board board = Board::parseBoard(9,9,R"%%(
+   A B C D E F G H J
+ 9 . . . X O X . X .
+ 8 . . . X O O X O X
+ 7 . . . X X O O . O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+)%%");
+    Rules rules;
+    rules.koRule = Rules::KO_SIMPLE;
+    rules.scoringRule = Rules::SCORING_TERRITORY;
+    rules.taxRule = Rules::TAX_ALL;
+    rules.multiStoneSuicideLegal = true;
+    rules.komi = 6.5f;
+    rules.hasButton = false;
+    BoardHistory hist(board,P_BLACK,rules,0);
+
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_BLACK, __LINE__);
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_WHITE, __LINE__);
+    makeMoveAssertLegal(hist, board, Location::getLoc(7,2,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(6,0,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(8,3,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(7,1,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(6,1,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    assert(hist.isLegal(board, Location::getLoc(7,2,board.x_size), P_WHITE));
+    makeMoveAssertLegal(hist, board, Location::getLoc(8,2,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    hist.printDebugInfo(out,board);
+
+    out << endl;
+    string expected = R"%%(
+HASH: 38C8C7F27510D958FD31111920914550
+   A B C D E F G H J
+ 9 . . . X O X . X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at H7
+HASH: C5436F2F449C44F2032BE90BF82BCFC6
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G9
+Ko recap blocked at H7
+HASH: C1B4C33B9023A5D5B071884C534BDE8D
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X .
+ 6 . . . . X X O O X
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G9
+Ko recap blocked at H7
+Ko recap blocked at J6
+HASH: 7E612069F9D69EAEEEAADC4E30CF728B
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O . O X
+ 7 . . . X X O O X .
+ 6 . . . . X X O O X
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G9
+Ko recap blocked at H8
+Ko recap blocked at H7
+Ko recap blocked at J6
+HASH: 7E612069F9D69EAEEEAADC4E30CF728B
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O . O X
+ 7 . . . X X O O X .
+ 6 . . . . X X O O X
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G9
+Ko recap blocked at H7
+Ko recap blocked at J6
+HASH: 5082A5AA1512BAD190D4C8951B76C472
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O . O X
+ 7 . . . X X O O . O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G9
+HASH: 5082A5AA1512BAD190D4C8951B76C472
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O . O X
+ 7 . . . X X O O . O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Initial pla Black
+Encore phase 1
+Turns this phase 6
+Rules koSIMPLEscoreTERRITORYtaxALLsui1komi6.5
+Ko recap block hash 6785AE217D0AAA7AD4FA074F6C3B370B
+White bonus score 3
+White handicap bonus score 0
+Has button 0
+Presumed next pla Black
+Past normal phase end 0
+Game result 0 Empty 0 0 0 0
+Last moves pass pass H7 G9 J6 H8 G8 J7
+
+)%%";
+    expect(name,out,expected);
+  }
+
+  {
+    const char* name = "Double ko death 2b";
+
+    Board board = Board::parseBoard(9,9,R"%%(
+   A B C D E F G H J
+ 9 . . . X O X . X .
+ 8 . . . X O O X O X
+ 7 . . . X X O O . O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+)%%");
+    Rules rules;
+    rules.koRule = Rules::KO_SIMPLE;
+    rules.scoringRule = Rules::SCORING_TERRITORY;
+    rules.taxRule = Rules::TAX_ALL;
+    rules.multiStoneSuicideLegal = true;
+    rules.komi = 6.5f;
+    rules.hasButton = false;
+    BoardHistory hist(board,P_BLACK,rules,0);
+
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_BLACK, __LINE__);
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_WHITE, __LINE__);
+    makeMoveAssertLegal(hist, board, Location::getLoc(7,2,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(6,0,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(8,3,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(7,1,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(7,1,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    assert(hist.isLegal(board, Location::getLoc(7,2,board.x_size), P_WHITE));
+    makeMoveAssertLegal(hist, board, Location::getLoc(8,3,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(6,1,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(8,2,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(5,0,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(7,2,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(5,0,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(7,1,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    printIllegalMoves(out,board,hist,P_BLACK);
+    assert(hist.isLegal(board, Location::getLoc(7,1,board.x_size), P_BLACK));
+    makeMoveAssertLegal(hist, board, Location::getLoc(7,2,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    printIllegalMoves(out,board,hist,P_BLACK);
+
+    hist.printDebugInfo(out,board);
+
+    out << endl;
+    string expected = R"%%(
+HASH: 38C8C7F27510D958FD31111920914550
+   A B C D E F G H J
+ 9 . . . X O X . X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at H7
+HASH: C5436F2F449C44F2032BE90BF82BCFC6
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G9
+Ko recap blocked at H7
+HASH: C1B4C33B9023A5D5B071884C534BDE8D
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X .
+ 6 . . . . X X O O X
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G9
+Ko recap blocked at H7
+Ko recap blocked at J6
+HASH: 7E612069F9D69EAEEEAADC4E30CF728B
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O . O X
+ 7 . . . X X O O X .
+ 6 . . . . X X O O X
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G9
+Ko recap blocked at H8
+Ko recap blocked at H7
+Ko recap blocked at J6
+HASH: 7E612069F9D69EAEEEAADC4E30CF728B
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O . O X
+ 7 . . . X X O O X .
+ 6 . . . . X X O O X
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G9
+Ko recap blocked at H7
+Ko recap blocked at J6
+HASH: 7E612069F9D69EAEEEAADC4E30CF728B
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O . O X
+ 7 . . . X X O O X .
+ 6 . . . . X X O O X
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G9
+Ko recap blocked at H7
+HASH: C1B4C33B9023A5D5B071884C534BDE8D
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X .
+ 6 . . . . X X O O X
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G9
+Ko recap blocked at G8
+Ko recap blocked at H7
+HASH: C5436F2F449C44F2032BE90BF82BCFC6
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G9
+Ko recap blocked at G8
+Ko recap blocked at H7
+Ko recap blocked at J7
+HASH: C5436F2F449C44F2032BE90BF82BCFC6
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G8
+Ko recap blocked at H7
+Ko recap blocked at J7
+HASH: C5436F2F449C44F2032BE90BF82BCFC6
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G8
+Ko recap blocked at J7
+HASH: 38C8C7F27510D958FD31111920914550
+   A B C D E F G H J
+ 9 . . . X O X . X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at F9
+Ko recap blocked at G8
+Ko recap blocked at J7
+HASH: F0D2D61BE0FABC60F06563748284EA95
+   A B C D E F G H J
+ 9 . . . X O X . X .
+ 8 . . . X O O X O X
+ 7 . . . X X O O . O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at F9
+Ko recap blocked at G8
+Ko recap blocked at H8
+Ko recap blocked at J7
+Ko-recap-blocked: (5,0)
+Ko-recap-blocked: (6,1)
+Ko-recap-blocked: (7,1)
+Ko-recap-blocked: (8,2)
+HASH: F0D2D61BE0FABC60F06563748284EA95
+   A B C D E F G H J
+ 9 . . . X O X . X .
+ 8 . . . X O O X O X
+ 7 . . . X X O O . O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at F9
+Ko recap blocked at G8
+Ko recap blocked at J7
+HASH: F0D2D61BE0FABC60F06563748284EA95
+   A B C D E F G H J
+ 9 . . . X O X . X .
+ 8 . . . X O O X O X
+ 7 . . . X X O O . O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at F9
+Ko recap blocked at G8
+Ko recap blocked at J7
+Ko-recap-blocked: (5,0)
+Ko-recap-blocked: (6,1)
+Illegal: (7,2) X
+Ko-recap-blocked: (8,2)
+HASH: F0D2D61BE0FABC60F06563748284EA95
+   A B C D E F G H J
+ 9 . . . X O X . X .
+ 8 . . . X O O X O X
+ 7 . . . X X O O . O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Initial pla Black
+Encore phase 1
+Turns this phase 14
+Rules koSIMPLEscoreTERRITORYtaxALLsui1komi6.5
+Ko recap block hash B442956CD0B349EA467256E307990942
+White bonus score 4
+White handicap bonus score 0
+Has button 0
+Presumed next pla Black
+Past normal phase end 0
+Game result 0 Empty 0 0 0 0
+Last moves pass pass H7 G9 J6 H8 H8 J6 G8 J7 F9 H7 F9 H8 H7 pass
+)%%";
+    expect(name,out,expected);
+  }
+
+  {
+    const char* name = "Double ko death 2c";
+
+    Board board = Board::parseBoard(9,9,R"%%(
+   A B C D E F G H J
+ 9 . . . X O X . X .
+ 8 . . . X O O X O X
+ 7 . . . X X O O . O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+)%%");
+    Rules rules;
+    rules.koRule = Rules::KO_SIMPLE;
+    rules.scoringRule = Rules::SCORING_TERRITORY;
+    rules.taxRule = Rules::TAX_ALL;
+    rules.multiStoneSuicideLegal = true;
+    rules.komi = 6.5f;
+    rules.hasButton = false;
+    BoardHistory hist(board,P_BLACK,rules,0);
+
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_BLACK, __LINE__);
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_WHITE, __LINE__);
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_BLACK, __LINE__);
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_WHITE, __LINE__);
+    makeMoveAssertLegal(hist, board, Location::getLoc(7,2,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(6,0,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(8,3,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(7,1,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    assert(!hist.isLegal(board, Location::getLoc(6,0,board.x_size), P_BLACK));
+    makeMoveAssertLegal(hist, board, Location::getLoc(7,1,board.x_size), P_BLACK, __LINE__);
+    hist.printDebugInfo(out,board);
+    out << endl;
+    string expected = R"%%(
+HASH: 38C8C7F27510D958FD31111920914550
+   A B C D E F G H J
+ 9 . . . X O X . X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at H7
+HASH: C5436F2F449C44F2032BE90BF82BCFC6
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G9
+Ko recap blocked at H7
+HASH: C1B4C33B9023A5D5B071884C534BDE8D
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X .
+ 6 . . . . X X O O X
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G9
+Ko recap blocked at H7
+Ko recap blocked at J6
+HASH: 7E612069F9D69EAEEEAADC4E30CF728B
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O . O X
+ 7 . . . X X O O X .
+ 6 . . . . X X O O X
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G9
+Ko recap blocked at H8
+Ko recap blocked at H7
+Ko recap blocked at J6
+HASH: 7E612069F9D69EAEEEAADC4E30CF728B
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O . O X
+ 7 . . . X X O O X .
+ 6 . . . . X X O O X
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Initial pla Black
+Encore phase 2
+Turns this phase 5
+Rules koSIMPLEscoreTERRITORYtaxALLsui1komi6.5
+Ko recap block hash B8D94C36535B1329F3E635C5794FEEA9
+White bonus score 4
+White handicap bonus score 0
+Has button 0
+Presumed next pla White
+Past normal phase end 0
+Game result 0 Empty 0 0 0 0
+Last moves pass pass pass pass H7 G9 J6 H8 H8
+
+)%%";
+    expect(name,out,expected);
+  }
+
+  {
+    const char* name = "Double ko death 2d";
+
+    Board board = Board::parseBoard(9,9,R"%%(
+   A B C D E F G H J
+ 9 . . . X O X . X .
+ 8 . . . X O O X O X
+ 7 . . . X X O O . O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+)%%");
+    Rules rules;
+    rules.koRule = Rules::KO_SIMPLE;
+    rules.scoringRule = Rules::SCORING_TERRITORY;
+    rules.taxRule = Rules::TAX_ALL;
+    rules.multiStoneSuicideLegal = true;
+    rules.komi = 6.5f;
+    rules.hasButton = false;
+    BoardHistory hist(board,P_BLACK,rules,0);
+
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_BLACK, __LINE__);
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_WHITE, __LINE__);
+    makeMoveAssertLegal(hist, board, Location::getLoc(7,2,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(6,0,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(8,3,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(7,1,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(6,1,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(7,2,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(6,1,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(8,2,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(5,0,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    hist.printDebugInfo(out,board);
+
+    out << endl;
+    string expected = R"%%(
+HASH: 38C8C7F27510D958FD31111920914550
+   A B C D E F G H J
+ 9 . . . X O X . X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at H7
+HASH: C5436F2F449C44F2032BE90BF82BCFC6
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G9
+Ko recap blocked at H7
+HASH: C1B4C33B9023A5D5B071884C534BDE8D
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X .
+ 6 . . . . X X O O X
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G9
+Ko recap blocked at H7
+Ko recap blocked at J6
+HASH: 7E612069F9D69EAEEEAADC4E30CF728B
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O . O X
+ 7 . . . X X O O X .
+ 6 . . . . X X O O X
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G9
+Ko recap blocked at H8
+Ko recap blocked at H7
+Ko recap blocked at J6
+HASH: 7E612069F9D69EAEEEAADC4E30CF728B
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O . O X
+ 7 . . . X X O O X .
+ 6 . . . . X X O O X
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G9
+Ko recap blocked at H7
+Ko recap blocked at J6
+HASH: 7E612069F9D69EAEEEAADC4E30CF728B
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O . O X
+ 7 . . . X X O O X .
+ 6 . . . . X X O O X
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G9
+Ko recap blocked at J6
+HASH: C1B4C33B9023A5D5B071884C534BDE8D
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X .
+ 6 . . . . X X O O X
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G9
+Ko recap blocked at G8
+Ko recap blocked at J6
+HASH: C1B4C33B9023A5D5B071884C534BDE8D
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X .
+ 6 . . . . X X O O X
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G9
+Ko recap blocked at G8
+HASH: 677629FFD07EEF1B0E2EA53AD5DC28BC
+   A B C D E F G H J
+ 9 . . . X . X . X .
+ 8 . . . X . . X . X
+ 7 . . . X X . . X .
+ 6 . . . . X X . . X
+ 5 . . . . . X X . .
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G8
+HASH: 677629FFD07EEF1B0E2EA53AD5DC28BC
+   A B C D E F G H J
+ 9 . . . X . X . X .
+ 8 . . . X . . X . X
+ 7 . . . X X . . X .
+ 6 . . . . X X . . X
+ 5 . . . . . X X . .
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Initial pla Black
+Encore phase 1
+Turns this phase 9
+Rules koSIMPLEscoreTERRITORYtaxALLsui1komi6.5
+Ko recap block hash 6DF578E5C17193F2108E72E5D4BA22A5
+White bonus score 6
+White handicap bonus score 0
+Has button 0
+Presumed next pla White
+Past normal phase end 0
+Game result 0 Empty 0 0 0 0
+Last moves pass pass H7 G9 J6 H8 G8 H7 G8 J7 F9
+
+)%%";
+    expect(name,out,expected);
+  }
+
+  {
+    const char* name = "Double ko death 2e";
+
+    Board board = Board::parseBoard(9,9,R"%%(
+   A B C D E F G H J
+ 9 . . . X O X . X .
+ 8 . . . X O O X O X
+ 7 . . . X X O O . O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+)%%");
+    Rules rules;
+    rules.koRule = Rules::KO_SIMPLE;
+    rules.scoringRule = Rules::SCORING_TERRITORY;
+    rules.taxRule = Rules::TAX_ALL;
+    rules.multiStoneSuicideLegal = true;
+    rules.komi = 6.5f;
+    rules.hasButton = false;
+    BoardHistory hist(board,P_BLACK,rules,0);
+
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_BLACK, __LINE__);
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_WHITE, __LINE__);
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_BLACK, __LINE__);
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_WHITE, __LINE__);
+    makeMoveAssertLegal(hist, board, Location::getLoc(7,2,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(6,0,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(5,0,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(7,1,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    hist.printDebugInfo(out,board);
+
+    out << endl;
+    string expected = R"%%(
+HASH: 38C8C7F27510D958FD31111920914550
+   A B C D E F G H J
+ 9 . . . X O X . X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at H7
+HASH: C5436F2F449C44F2032BE90BF82BCFC6
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G9
+Ko recap blocked at H7
+HASH: C5436F2F449C44F2032BE90BF82BCFC6
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at H7
+HASH: 5082A5AA1512BAD190D4C8951B76C472
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O . O X
+ 7 . . . X X O O . O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+HASH: 5082A5AA1512BAD190D4C8951B76C472
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O . O X
+ 7 . . . X X O O . O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Initial pla Black
+Encore phase 2
+Turns this phase 4
+Rules koSIMPLEscoreTERRITORYtaxALLsui1komi6.5
+Ko recap block hash 00000000000000000000000000000000
+White bonus score 4
+White handicap bonus score 0
+Has button 0
+Presumed next pla Black
+Past normal phase end 0
+Game result 0 Empty 0 0 0 0
+Last moves pass pass pass pass H7 G9 F9 H8
+
+)%%";
+    expect(name,out,expected);
+  }
+
+  {
+    const char* name = "Double ko death 2f";
+
+    Board board = Board::parseBoard(9,9,R"%%(
+   A B C D E F G H J
+ 9 . . . X O X . X .
+ 8 . . . X O O X O X
+ 7 . . . X X O O . O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+)%%");
+    Rules rules;
+    rules.koRule = Rules::KO_SIMPLE;
+    rules.scoringRule = Rules::SCORING_TERRITORY;
+    rules.taxRule = Rules::TAX_ALL;
+    rules.multiStoneSuicideLegal = true;
+    rules.komi = 6.5f;
+    rules.hasButton = false;
+    BoardHistory hist(board,P_BLACK,rules,0);
+
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_BLACK, __LINE__);
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_WHITE, __LINE__);
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_BLACK, __LINE__);
+    makeMoveAssertLegal(hist, board, Board::PASS_LOC, P_WHITE, __LINE__);
+    makeMoveAssertLegal(hist, board, Location::getLoc(7,2,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(6,0,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(5,0,board.x_size), P_BLACK, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    makeMoveAssertLegal(hist, board, Location::getLoc(7,2,board.x_size), P_WHITE, __LINE__);
+    out << board << endl;
+    printEncoreKoBlock(out,board,hist);
+    hist.printDebugInfo(out,board);
+
+    out << endl;
+    string expected = R"%%(
+HASH: 38C8C7F27510D958FD31111920914550
+   A B C D E F G H J
+ 9 . . . X O X . X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at H7
+HASH: C5436F2F449C44F2032BE90BF82BCFC6
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at G9
+Ko recap blocked at H7
+HASH: C5436F2F449C44F2032BE90BF82BCFC6
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Ko recap blocked at H7
+HASH: C5436F2F449C44F2032BE90BF82BCFC6
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+HASH: C5436F2F449C44F2032BE90BF82BCFC6
+   A B C D E F G H J
+ 9 . . . X O . O X .
+ 8 . . . X O O X . X
+ 7 . . . X X O O X O
+ 6 . . . . X X O O .
+ 5 . . . . . X X O O
+ 4 . . . . . . X X X
+ 3 . . . . . . . . .
+ 2 . . . . . . . . .
+ 1 . . . . . . . . .
+
+
+Initial pla Black
+Encore phase 2
+Turns this phase 4
+Rules koSIMPLEscoreTERRITORYtaxALLsui1komi6.5
+Ko recap block hash 00000000000000000000000000000000
+White bonus score 4
+White handicap bonus score 0
+Has button 0
+Presumed next pla Black
+Past normal phase end 0
+Game result 0 Empty 0 0 0 0
+Last moves pass pass pass pass H7 G9 F9 H7
+
 )%%";
     expect(name,out,expected);
   }

--- a/docs/rulesv1.html
+++ b/docs/rulesv1.html
@@ -216,8 +216,11 @@ window.onload = function() {
 </head>
 <body>
 
-<h1>KataGo's Supported Go Rules (Version 2) </h1>
-This page describes the full rigorous rules implemented by KataGo. Updated from <a href="./rulesv1.html">rules version 1</a> right around the start of 2021 to fix an issue where basic double ko death was a mismatch with Japanese rules. These rules are supported in KataGo version 1.8 and later. Additionally, neural nets trained with the old rules, before 2021 or in early 2021 may fail to evaluate such situations correctly even when used with KataGo version 1.8 or later - the version *and* the net both need to be up-to-date.
+<h1>KataGo's Supported Go Rules (Version 1) </h1>
+
+This is NOT the latest version of these rules. The latest rules can be found <a href="./rules.html">here</a>.
+
+This page describes the full rigorous rules implemented by KataGo. These rules are supported in KataGo version 1.3 and later.
 
 <p>
 A hope also is that this document can serve as a reference for anyone to implement any subset of such rules themselves - including a rigorous nearly-Japanese rules that bots can use for self-play or for competitive matches completely without need for outside adjudication or dispute resolution or any other protocol besides just the bots making ordinary plays.
@@ -520,7 +523,7 @@ Cleanup lasts for two phases<a href="#note6" id="ref6">[6]</a>. In each phase, s
   </ul>
   Then, followed by unmarking all ko-recapture-blocked points whose grid color is empty.
 </li>
-<li>An <span class="definition">unblock-ko-recapture</span> action consists of a player choosing a a single-point region of the opposing color that is in atari and marked as ko-recapture-blocked, and removing that mark.</li>
+<li>An <span class="definition">unblock-ko-recapture</span> action consists of a player choosing a ko-move for that player that would capture a region containing a point marked as ko-recapture-blocked, and removing that mark.</li>
 </ul>
 
 <h4> Cleanup Phase Ending and Scoring </h4>


### PR DESCRIPTION
Fixes a bug in the implementation of Japanese rules that would cause misevaluation of basic double ko death.

See discussion here of the issue:
https://lifein19x19.com/viewtopic.php?f=45&t=17963

