### PR TITLE
Fix buffer overrun in Tests::runBoardAreaTests()

### DIFF
--- a/cpp/tests/testboardarea.cpp
+++ b/cpp/tests/testboardarea.cpp
@@ -1588,7 +1588,7 @@ o.oxo.o...x.x
     bool unsafeBigTerritories = true;
     board.calculateArea(result,nonPassAliveStones,safeBigTerritories,unsafeBigTerritories,multiStoneSuicideLegal);
 
-    float scoring[NNPos::MAX_BOARD_AREA];
+    float scoring[Board::MAX_ARR_SIZE];
 
     out << endl;
     out << "No group tax" << endl;
@@ -1674,7 +1674,7 @@ ox.oxo.o.x.o.
     bool unsafeBigTerritories = false;
     board.calculateArea(result,nonPassAliveStones,safeBigTerritories,unsafeBigTerritories,multiStoneSuicideLegal);
 
-    float scoring[NNPos::MAX_BOARD_AREA];
+    float scoring[Board::MAX_ARR_SIZE];
 
     out << endl;
     out << "No group tax" << endl;
@@ -1760,7 +1760,7 @@ ox.oxo.o.x.o.
     bool unsafeBigTerritories = true;
     board.calculateArea(result,nonPassAliveStones,safeBigTerritories,unsafeBigTerritories,multiStoneSuicideLegal);
 
-    float scoring[NNPos::MAX_BOARD_AREA];
+    float scoring[Board::MAX_ARR_SIZE];
 
     out << endl;
     out << "No group tax" << endl;


### PR DESCRIPTION
`NNInputs::fillScoring()` uses `Board::MAX_ARR_SIZE`, but tests use `NNPos::MAX_BOARD_AREA`