### PR TITLE
Ensure performance reported

### DIFF
--- a/cpp/command/contribute.cpp
+++ b/cpp/command/contribute.cpp
@@ -1061,6 +1061,7 @@ int MainCmds::contribute(int argc, const char* const* argv) {
   //Wait for all task loop threads to stop
   for(int i = 0; i<taskLoopThreads.size(); i++)
     taskLoopThreads[i].join();
+  maybePrintPerformanceUnsynchronized();
 
   logger.write("Beginning shutdown");
 


### PR DESCRIPTION
In some corner cases, ex. hit ctrl-c when all task loops are downloading models, performance would not be reported.