### PR TITLE
Watch multiple games

### DIFF
--- a/cpp/command/contribute.cpp
+++ b/cpp/command/contribute.cpp
@@ -171,12 +171,14 @@ static void runAndUploadSingleGame(
   const string gameIdString = Global::uint64ToHexString(rand.nextUInt64());
 
   std::function<void(const Board&, const BoardHistory&, Player, Loc, const std::vector<double>&, const std::vector<double>&, const std::vector<double>&, const Search*)>
-    onEachMove = [&numMovesPlayed, &outputEachMove, &flushOutputEachMove, &logGamesAsJson, &alwaysIncludeOwnership, &gameIdString, &botSpecB, &botSpecW](
+    onEachMove = [&numMovesPlayed, &outputEachMove, &flushOutputEachMove, &logGamesAsJson, &alwaysIncludeOwnership, &gameIdx, &gameIdString, &botSpecB, &botSpecW](
       const Board& board, const BoardHistory& hist, Player pla, Loc moveLoc,
       const std::vector<double>& winLossHist, const std::vector<double>& leadHist, const std::vector<double>& scoreStdevHist, const Search* search) {
     numMovesPlayed.fetch_add(1,std::memory_order_relaxed);
     if(outputEachMove != nullptr) {
       ostringstream out;
+      out << "Thread: " << Global::intToString(gameIdx) << "\n";
+      out << "GameID: " << gameIDString << "\n";
       Board::printBoard(out, board, moveLoc, &(hist.moveHistory));
       if(botSpecB.botName == botSpecW.botName) {
         out << "Network: " << botSpecB.botName << "\n";

--- a/cpp/command/contribute.cpp
+++ b/cpp/command/contribute.cpp
@@ -177,8 +177,7 @@ static void runAndUploadSingleGame(
     numMovesPlayed.fetch_add(1,std::memory_order_relaxed);
     if(outputEachMove != nullptr) {
       ostringstream out;
-      out << "Thread: " << Global::intToString(gameIdx) << "\n";
-      out << "GameID: " << gameIdString << "\n";
+      out << "Game #" << Global::intToString(gameIdx) << " (" << gameIdString << ")\n";
       Board::printBoard(out, board, moveLoc, &(hist.moveHistory));
       if(botSpecB.botName == botSpecW.botName) {
         out << "Network: " << botSpecB.botName << "\n";

--- a/cpp/command/contribute.cpp
+++ b/cpp/command/contribute.cpp
@@ -533,6 +533,7 @@ int MainCmds::contribute(int argc, const char* const* argv) {
 
   const double reportPerformanceEvery = userCfg->contains("reportPerformanceEvery") ? userCfg->getDouble("reportPerformanceEvery", 1, 21600) : 120;
   const bool watchOngoingGameInFile = userCfg->contains("watchOngoingGameInFile") ? userCfg->getBool("watchOngoingGameInFile") : false;
+  const int watchOngoingGameMaxCount = userCfg->contains("watchOngoingGameMaxCount") ? userCfg->getInt("watchOngoingGameMaxCount", 0, maxSimultaneousGames) : false;
   string watchOngoingGameInFileName = userCfg->contains("watchOngoingGameInFileName") ? userCfg->getString("watchOngoingGameInFileName") : "";
   const bool logGamesAsJson = userCfg->contains("logGamesAsJson") ? userCfg->getBool("logGamesAsJson") : false;
   const bool alwaysIncludeOwnership = userCfg->contains("includeOwnership") ? userCfg->getBool("includeOwnership") : false;
@@ -655,7 +656,7 @@ int MainCmds::contribute(int argc, const char* const* argv) {
 
   auto runGameLoop = [
     &logger,forkData,&gameSeedBase,&gameTaskQueue,&numGamesStarted,&sgfsDir,&connection,
-    &numRatingGamesActive,&numMovesPlayed,&watchOngoingGameInFile,&watchOngoingGameInFileName,
+    &numRatingGamesActive,&numMovesPlayed,&watchOngoingGameInFile,&watchOngoingGameMaxCount,&watchOngoingGameInFileName,
     &shouldStopFunc,&shouldStopGracefullyFunc,
     &logGamesAsJson, &alwaysIncludeOwnership
   ] (
@@ -663,7 +664,7 @@ int MainCmds::contribute(int argc, const char* const* argv) {
   ) {
     std::unique_ptr<std::ostream> outputEachMove = nullptr;
     std::function<void()> flushOutputEachMove = nullptr;
-    if(gameLoopThreadIdx == 0 && watchOngoingGameInFile) {
+    if(gameLoopThreadIdx < watchOngoingGameMaxCount && watchOngoingGameInFile) {
 #ifdef OS_IS_WINDOWS
       FILE* file = NULL;
       fopen_s(&file, watchOngoingGameInFileName.c_str(), "a");

--- a/cpp/command/contribute.cpp
+++ b/cpp/command/contribute.cpp
@@ -178,7 +178,7 @@ static void runAndUploadSingleGame(
     if(outputEachMove != nullptr) {
       ostringstream out;
       out << "Thread: " << Global::intToString(gameIdx) << "\n";
-      out << "GameID: " << gameIDString << "\n";
+      out << "GameID: " << gameIdString << "\n";
       Board::printBoard(out, board, moveLoc, &(hist.moveHistory));
       if(botSpecB.botName == botSpecW.botName) {
         out << "Network: " << botSpecB.botName << "\n";

--- a/cpp/configs/contribute_example.cfg
+++ b/cpp/configs/contribute_example.cfg
@@ -15,6 +15,7 @@ maxSimultaneousGames = Fill in a number here
 # Windows Powershell: "Get-Content .\watchgame.txt -Tail 50 -Wait"
 watchOngoingGameInFile = false
 watchOngoingGameInFileName = watchgame.txt
+watchOngoingGameMaxCount = 1
 
 # If you use an https proxy to connect to the internet, set these to the host and port of your proxy.
 # proxyHost = HOSTNAME


### PR DESCRIPTION
### Motivation
Sometimes an ongoing game gets boring so we should output multiple games so people can watch the most interesting one, or enable the watching app to pick.

### Proposal
Add an option called `watchOngoingGameMaxCount` that lets the user choose how many games they want in the watchGame file. In order to identify the games, additional output like game index and game id are also output.

Instead of the 0th thread writing to the file, now all threads whose index is less than `watchOngoingGameMaxCount` will output their moves.

Example new generated output:
```
Game #0 (A1CFF3FF47AFF5E4)
MoveNum: 6 HASH: F7F68A6B34005BEC6164319478DE21AD
   A B C D E F G H
12 . . . . . . . .
11 . . . . . . . .
10 . . . . O1. . .
 9 . . . O . X . .
 8 . . . . O3. . .
 7 . . . . X2@ . .
 6 . . . . . . . .
 5 . . . . . . . .
 4 . . . . . . . .
 3 . . . . X . . .
 2 . . . . . . . .
 1 . . . . . . . .

Network: rect15-b20c256-s343365760-d96847752
Rules: {"friendlyPassOk":false,"hasButton":false,"ko":"SIMPLE","komi":6.5,"scoring":"AREA","suicide":true,"tax":"NONE","whiteHandicapBonus":"0"}
Player: Black
Move: F7
Num Visits: 1200
Black Winrate: 47.0417%
Black Lead: 0.0853327
```

### Alternatives considered
Let each thread output to their own files, but then we need infrastructure to let the user set the output file pattern. Just seems like too much work.