### PR TITLE
minor changes on trim a string

### DIFF
--- a/cpp/core/global.cpp
+++ b/cpp/core/global.cpp
@@ -288,13 +288,10 @@ string Global::chopSuffix(const string& s, const string& suffix)
 
 string Global::trim(const string& s)
 {
-  size_t p2 = s.find_last_not_of(" \t\r\n");
+  size_t p2 = s.find_last_not_of(" \t\r\n\v\f");
   if (p2 == string::npos)
     return string();
-  size_t p1 = s.find_first_not_of(" \t\r\n");
-  if (p1 == string::npos)
-    p1 = 0;
-
+  size_t p1 = s.find_first_not_of(" \t\r\n\v\f");
   return s.substr(p1,(p2-p1)+1);
 }
 

--- a/cpp/game/board.cpp
+++ b/cpp/game/board.cpp
@@ -2600,20 +2600,17 @@ Board Board::parseBoard(int xSize, int ySize, const string& s, char lineDelimite
     while(firstNonDigitIdx < line.length() && Global::isDigit(line[firstNonDigitIdx]))
       firstNonDigitIdx++;
     line.erase(0,firstNonDigitIdx);
-    line = Global::trim(line);
+    line.erase(std::remove_if(line.begin(), line.end(), [](char c){
+      return std::isspace(static_cast<unsigned char>(c));
+    }),line.end());
 
-    if(line.length() != xSize && line.length() != 2*xSize-1)
+    if(line.length() != xSize)
       throw StringError("Board::parseBoard - line length not compatible with xSize");
 
     for(int x = 0; x<xSize; x++) {
-      char c;
-      if(line.length() == xSize)
-        c = line[x];
-      else
-        c = line[x*2];
-
+      char c = line[x];
       Loc loc = Location::getLoc(x,y,board.x_size);
-      if(c == '.' || c == ' ' || c == '*' || c == ',' || c == '`')
+      if(c == '.' || c == '*' || c == ',' || c == '`')
         continue;
       else if(c == 'o' || c == 'O')
         board.setStone(loc,P_WHITE);
@@ -2623,5 +2620,5 @@ Board Board::parseBoard(int xSize, int ySize, const string& s, char lineDelimite
         throw StringError(string("Board::parseBoard - could not parse board character: ") + c);
     }
   }
-  return board;
+  return board; //may need to consider to add a move constructor 
 }

--- a/cpp/game/board.cpp
+++ b/cpp/game/board.cpp
@@ -2620,5 +2620,5 @@ Board Board::parseBoard(int xSize, int ySize, const string& s, char lineDelimite
         throw StringError(string("Board::parseBoard - could not parse board character: ") + c);
     }
   }
-  return board; //may need to consider to add a move constructor 
+  return board; //may need to consider to add a move constructor and move assignment operator for board class
 }


### PR DESCRIPTION
Very minor changes. Since we already checked

```
if (p2 == string::npos)
    return string();
```
So we do not need `if (p1== string::npos) p1 = 0`.
I also added white space string as \v\f into " \t\r\n\v\f" based on C++ reference. All are very minor changes.
This change has passed all the test in the test folder folder. 