### PR TITLE
Fast terminal fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ cpp/tests/scratch
 
 cpp/program/gitinfo.h
 
-data/
+cpp/data/
 versions/
 cpp/build
 

--- a/cpp/neuralnet/nneval.h
+++ b/cpp/neuralnet/nneval.h
@@ -144,6 +144,10 @@ class NNEvaluator {
     bool includeOwnerMap
   );
 
+  //If there is at least one evaluate ongoing, wait until at least one finishes.
+  //Returns immediately if there isn't one ongoing right now.
+  void waitForNextNNEvalIfAny();
+
   //Actually spawn threads to handle evaluations.
   //If doRandomize, uses randSeed as a seed, further randomized per-thread
   //If not doRandomize, uses defaultSymmetry for all nn evaluations, unless a symmetry is requested in MiscNNInputParams.
@@ -214,6 +218,11 @@ class NNEvaluator {
   bool isKilled; //Flag used for killing server threads
   int numServerThreadsStartingUp; //Counter for waiting until server threads are spawned
   std::condition_variable mainThreadWaitingForSpawn; //Condvar for waiting until server threads are spawned
+
+  int numOngoingEvals; //Current number of ongoing evals.
+  int numWaitingEvals; //Current number of things waiting for finish.
+  int numEvalsToAwaken; //Current number of things waitingForFinish that should be woken up. Used to avoid spurious wakeups.
+  std::condition_variable waitingForFinish; //Condvar for waiting for at least one ongoing eval to finish.
 
   //Randomization settings for symmetries
   bool currentDoRandomize;

--- a/cpp/tests/data/foxlike.sgf
+++ b/cpp/tests/data/foxlike.sgf
@@ -1,0 +1,1 @@
+(;GM[1]FF[4]  SZ[19]  GN[]  DT[2021-01-01]  PB[testname1]  PW[testname2]  BR[3段]  WR[5段]  KM[325]HA[2]RU[Chinese]AP[GNU Go:3.8]RE[draw]TM[60]TC[10]TT[60]AP[foxwq]RL[0]  ;AB[pd][dp];W[dc];B[ce];)


### PR DESCRIPTION
I think this should fix https://github.com/lightvector/KataGo/issues/473, which is caused by terminal nodes of the search running too fast and getting a too-large number of playouts while other threads are blocked on results from the GPU.