### PR TITLE
Slightly changed calculateAreaForPla to improve efficiency

### DIFF
--- a/cpp/game/board.cpp
+++ b/cpp/game/board.cpp
@@ -1984,27 +1984,23 @@ void Board::calculateAreaForPla(
   bool plaHasBeenKilled[MAX_PLAY_SIZE];
   memset(plaHasBeenKilled, false, sizeof(plaHasBeenKilled[0])*numPlaHeads);
 
+  //Zero out vital liberties by head
+  uint16_t vitalCountByPlaHead[MAX_ARR_SIZE];
+  for(int i = 0; i<numPlaHeads; ++i)
+    vitalCountByPlaHead[allPlaHeads[i]] = 0;
+
+  //Walk all regions that are still bordered only by pass-alive stuff and accumulate a vital liberty to each pla it is vital for.
+  for(int i = 0; i<numRegions; ++i) {
+    int vStart = vitalStart[i];
+    int vLen = vitalLen[i];
+    for(int j = 0; j<vLen; ++j) {
+      Loc plaHead = vitalForPlaHeadsLists[vStart+j];
+      vitalCountByPlaHead[plaHead] += 1;
+    }
+  }
 
   //Now, we can begin the benson iteration
-  uint16_t vitalCountByPlaHead[MAX_ARR_SIZE];
   while(true) {
-    //Zero out vital liberties by head
-    for(int i = 0; i<numPlaHeads; ++i)
-      vitalCountByPlaHead[allPlaHeads[i]] = 0;
-
-    //Walk all regions that are still bordered only by pass-alive stuff and accumulate a vital liberty to each pla it is vital for.
-    for(int i = 0; i<numRegions; ++i) {
-      if(bordersNonPassAlivePlaByHead[regionHeads[i]])
-        continue;
-
-      int vStart = vitalStart[i];
-      int vLen = vitalLen[i];
-      for(int j = 0; j<vLen; ++j) {
-        Loc plaHead = vitalForPlaHeadsLists[vStart+j];
-        vitalCountByPlaHead[plaHead] += 1;
-      }
-    }
-
     //Walk all player heads and kill them if they haven't accumulated at least 2 vital liberties
     bool killedAnything = false;
     for(int i = 0; i<numPlaHeads; ++i) {
@@ -2019,11 +2015,19 @@ void Board::calculateAreaForPla(
         //Walk the pla chain to update bordering regions
         Loc cur = plaHead;
         do {
-          FOREACHADJ(
-              Loc adj = cur + ADJOFFSET;
-              if(colors[adj] == C_EMPTY || colors[adj] == opp)
-                bordersNonPassAlivePlaByHead[regionHeads[regionIdxByLoc[adj]]] = true;
-          );
+          for(int j = 0; j<4; ++j) {
+            Loc adj = cur + adj_offsets[j];
+            Loc regionIdx = regionIdxByLoc[adj];
+            if(!bordersNonPassAlivePlaByHead[regionHeads[regionIdx]] && (colors[adj] == C_EMPTY || colors[adj] == opp)){
+              bordersNonPassAlivePlaByHead[regionHeads[regionIdx]] = true;
+              int vStart = vitalStart[regionIdx];
+              int vLen = vitalLen[regionIdx];
+              for(int k = 0; k<vLen; ++k) {
+                Loc plaH = vitalForPlaHeadsLists[vStart+k];
+                vitalCountByPlaHead[plaH] -= 1;
+              }
+            }
+          }
           cur = next_in_chain[cur];
         } while (cur != plaHead);
       }

--- a/cpp/game/board.cpp
+++ b/cpp/game/board.cpp
@@ -1799,11 +1799,11 @@ void Board::calculateIndependentLifeArea(
 //it as white's unsafeBigTerritory because it's already marked as black's pass alive territory.
 
 void Board::calculateAreaForPla(
-  Player pla,
-  bool safeBigTerritories,
-  bool unsafeBigTerritories,
-  bool isMultiStoneSuicideLegal,
-  Color* result
+    Player pla,
+    bool safeBigTerritories,
+    bool unsafeBigTerritories,
+    bool isMultiStoneSuicideLegal,
+    Color* result
 ) const {
   Color opp = getOpp(pla);
 
@@ -1817,6 +1817,12 @@ void Board::calculateAreaForPla(
   Loc nextEmptyOrOpp[MAX_ARR_SIZE];
   //Does this border a pla group that has been marked as not pass alive?
   bool bordersNonPassAlivePlaByHead[MAX_ARR_SIZE];
+
+  //set to initial values. Faster than std::fill in O2 optimization by compiler, might be similar when use O3.
+  memset(regionIdxByLoc, -1, sizeof(regionIdxByLoc[0])*MAX_ARR_SIZE);
+  memset(nextEmptyOrOpp, NULL_LOC, sizeof(nextEmptyOrOpp[0])*MAX_ARR_SIZE);
+  memset(bordersNonPassAlivePlaByHead, false, sizeof(bordersNonPassAlivePlaByHead[0])*MAX_ARR_SIZE);
+
 
   //A list for each region head, indicating which pla group heads the region is vital for.
   //A region is vital for a pla group if all its spaces are adjacent to that pla group.
@@ -1837,21 +1843,6 @@ void Board::calculateAreaForPla(
   uint8_t numInternalSpacesMax2[maxRegions];
   bool containsOpp[maxRegions];
 
-  for(int i = 0; i<MAX_ARR_SIZE; i++) {
-    regionIdxByLoc[i] = -1;
-    nextEmptyOrOpp[i] = NULL_LOC;
-    bordersNonPassAlivePlaByHead[i] = false;
-  }
-
-  auto isAdjacentToPlaHead = [pla,this](Loc loc, Loc plaHead) {
-    FOREACHADJ(
-      Loc adj = loc + ADJOFFSET;
-      if(colors[adj] == pla && chain_head[adj] == plaHead)
-        return true;
-    );
-    return false;
-  };
-
   //Breadth-first-search trace maximal non-pla regions of the board and record their properties and join them into a
   //linked list through nextEmptyOrOpp.
   //Takes as input the location serving as the head, the tip node of the linked list so far, the next loc, and the
@@ -1861,18 +1852,18 @@ void Board::calculateAreaForPla(
   Loc buildRegionQueue[MAX_ARR_SIZE];
 
   auto buildRegion = [
-    pla,opp,isMultiStoneSuicideLegal,
-    &regionIdxByLoc,
-    &vitalForPlaHeadsLists,
-    &vitalStart,&vitalLen,&numInternalSpacesMax2,&containsOpp,
-    &buildRegionQueue,
-    this,
-    &isAdjacentToPlaHead,&nextEmptyOrOpp](Loc tailTarget, Loc initialLoc, int regionIdx) -> Loc {
-
-    //Already traced this location, skip
-    if(regionIdxByLoc[initialLoc] != -1)
-      return tailTarget;
-
+      pla,opp,isMultiStoneSuicideLegal,
+      &regionIdxByLoc,
+      &vitalForPlaHeadsLists,
+      &vitalStart,&vitalLen,&numInternalSpacesMax2,&containsOpp,
+      &buildRegionQueue,
+      this,
+      &nextEmptyOrOpp](Loc initialLoc, int regionIdx) -> Loc {
+    //this code use a queue to build region. Starting from a new position which means (assume the input)
+    //  already checked that regionIdxByLoc[initialLoc] == -1 before calling this function
+    //  therefore,  the tailTarget start from initialLoc
+    Loc tailTarget = initialLoc;
+    bool isVlenNonZero = vitalLen[regionIdx]>0;
     int buildRegionQueueHead = 0;
     int buildRegionQueueTail = 1;
     buildRegionQueue[0] = initialLoc;
@@ -1886,24 +1877,24 @@ void Board::calculateAreaForPla(
       //First, filter out any pla heads it turns out we're not vital for because we're not adjacent to them
       //In the case where suicide is disallowed, we only do this filtering on intersections that are actually empty
       {
-        if(isMultiStoneSuicideLegal || colors[loc] == C_EMPTY) {
+        if(isVlenNonZero && (isMultiStoneSuicideLegal || colors[loc] == C_EMPTY)) {
           uint16_t vStart = vitalStart[regionIdx];
           uint16_t oldVLen = vitalLen[regionIdx];
           uint16_t newVLen = 0;
           for(uint16_t i = 0; i<oldVLen; i++) {
-            if(isAdjacentToPlaHead(loc,vitalForPlaHeadsLists[vStart+i])) {
+            if(isAdjacentToPlaHead(pla, loc,vitalForPlaHeadsLists[vStart+i])) {
               vitalForPlaHeadsLists[vStart+newVLen] = vitalForPlaHeadsLists[vStart+i];
               newVLen += 1;
             }
           }
           vitalLen[regionIdx] = newVLen;
+          isVlenNonZero = (newVLen>0);
         }
       }
 
       //Determine if this point is internal, unless we already have many internal points
-      if(numInternalSpacesMax2[regionIdx] < 2) {
-        if(!isAdjacentToPla(loc,pla))
-          numInternalSpacesMax2[regionIdx] += 1;
+      if(numInternalSpacesMax2[regionIdx] < 2 && !isAdjacentToPla(loc,pla)){
+        numInternalSpacesMax2[regionIdx] += 1;
       }
 
       if(colors[loc] == opp)
@@ -1912,25 +1903,24 @@ void Board::calculateAreaForPla(
       nextEmptyOrOpp[loc] = tailTarget;
       tailTarget = loc;
 
-      //Push adjacent locations on to queue
+      //Push adjacent locations on to queue.
       FOREACHADJ(
-        Loc adj = loc + ADJOFFSET;
-        if((colors[adj] == C_EMPTY || colors[adj] == opp) && regionIdxByLoc[adj] == -1) {
-          buildRegionQueue[buildRegionQueueTail] = adj;
-          buildRegionQueueTail += 1;
-          regionIdxByLoc[adj] = regionIdx;
-        }
+          Loc adj = loc + ADJOFFSET;
+          if((colors[adj] == C_EMPTY || colors[adj] == opp) && regionIdxByLoc[adj] == -1) {
+            buildRegionQueue[buildRegionQueueTail] = adj;
+            buildRegionQueueTail += 1;
+            regionIdxByLoc[adj] = regionIdx;
+          }
       );
     }
 
     assert(buildRegionQueueTail < MAX_ARR_SIZE);
-
     return tailTarget;
   };
 
   bool atLeastOnePla = false;
-  for(int y = 0; y < y_size; y++) {
-    for(int x = 0; x < x_size; x++) {
+  for(int y = 0; y < y_size; ++y) {
+    for(int x = 0; x < x_size; ++x) {
       Loc loc = Location::getLoc(x,y,x_size);
       if(regionIdxByLoc[loc] != -1)
         continue;
@@ -1939,12 +1929,11 @@ void Board::calculateAreaForPla(
         continue;
       }
       int16_t regionIdx = numRegions;
-      numRegions++;
+      ++numRegions;
       assert(numRegions <= maxRegions);
 
       //Initialize region metadata
-      Loc head = loc;
-      regionHeads[regionIdx] = head;
+      regionHeads[regionIdx] = loc;
       vitalStart[regionIdx] = vitalForPlaHeadsListsTotal;
       vitalLen[regionIdx] = 0;
       numInternalSpacesMax2[regionIdx] = 0;
@@ -1960,7 +1949,7 @@ void Board::calculateAreaForPla(
           if(colors[adj] == pla) {
             Loc plaHead = chain_head[adj];
             bool alreadyPresent = false;
-            for(int j = 0; j<initialVLen; j++) {
+            for(int j = 0; j<initialVLen; ++j) {
               if(vitalForPlaHeadsLists[vStart+j] == plaHead) {
                 alreadyPresent = true;
                 break;
@@ -1974,8 +1963,8 @@ void Board::calculateAreaForPla(
         }
         vitalLen[regionIdx] = initialVLen;
       }
-      Loc tailTarget = buildRegion(head,loc,regionIdx);
-      nextEmptyOrOpp[head] = tailTarget;
+      Loc tailTarget = buildRegion(loc,regionIdx);
+      nextEmptyOrOpp[loc] = tailTarget;
 
       vitalForPlaHeadsListsTotal += vitalLen[regionIdx];
 
@@ -1993,24 +1982,24 @@ void Board::calculateAreaForPla(
   }
 
   bool plaHasBeenKilled[MAX_PLAY_SIZE];
-  for(int i = 0; i<numPlaHeads; i++)
-    plaHasBeenKilled[i] = false;
+  memset(plaHasBeenKilled, false, sizeof(plaHasBeenKilled[0])*numPlaHeads);
+
 
   //Now, we can begin the benson iteration
   uint16_t vitalCountByPlaHead[MAX_ARR_SIZE];
   while(true) {
     //Zero out vital liberties by head
-    for(int i = 0; i<numPlaHeads; i++)
+    for(int i = 0; i<numPlaHeads; ++i)
       vitalCountByPlaHead[allPlaHeads[i]] = 0;
 
     //Walk all regions that are still bordered only by pass-alive stuff and accumulate a vital liberty to each pla it is vital for.
-    for(int i = 0; i<numRegions; i++) {
+    for(int i = 0; i<numRegions; ++i) {
       if(bordersNonPassAlivePlaByHead[regionHeads[i]])
         continue;
 
       int vStart = vitalStart[i];
       int vLen = vitalLen[i];
-      for(int j = 0; j<vLen; j++) {
+      for(int j = 0; j<vLen; ++j) {
         Loc plaHead = vitalForPlaHeadsLists[vStart+j];
         vitalCountByPlaHead[plaHead] += 1;
       }
@@ -2018,7 +2007,7 @@ void Board::calculateAreaForPla(
 
     //Walk all player heads and kill them if they haven't accumulated at least 2 vital liberties
     bool killedAnything = false;
-    for(int i = 0; i<numPlaHeads; i++) {
+    for(int i = 0; i<numPlaHeads; ++i) {
       //Already killed - skip
       if(plaHasBeenKilled[i])
         continue;
@@ -2031,9 +2020,9 @@ void Board::calculateAreaForPla(
         Loc cur = plaHead;
         do {
           FOREACHADJ(
-            Loc adj = cur + ADJOFFSET;
-            if(colors[adj] == C_EMPTY || colors[adj] == opp)
-              bordersNonPassAlivePlaByHead[regionHeads[regionIdxByLoc[adj]]] = true;
+              Loc adj = cur + ADJOFFSET;
+              if(colors[adj] == C_EMPTY || colors[adj] == opp)
+                bordersNonPassAlivePlaByHead[regionHeads[regionIdxByLoc[adj]]] = true;
           );
           cur = next_in_chain[cur];
         } while (cur != plaHead);
@@ -2046,7 +2035,7 @@ void Board::calculateAreaForPla(
 
 
   //Mark result with pass-alive groups
-  for(int i = 0; i<numPlaHeads; i++) {
+  for(int i = 0; i<numPlaHeads; ++i) {
     if(!plaHasBeenKilled[i]) {
       Loc plaHead = allPlaHeads[i];
       Loc cur = plaHead;
@@ -2065,8 +2054,8 @@ void Board::calculateAreaForPla(
     //These should be mutually exclusive with these same regions but for the opponent, so this is safe.
     //We need to mark unconditionally since we WILL sometimes overwrite points of the opponent's color marked earlier, in the
     //case that the opponent was marking unsafeBigTerritories and marked an empty spot surrounded by a pass-dead group.
-    bool shouldMark = numInternalSpacesMax2[i] <= 1 && atLeastOnePla && !bordersNonPassAlivePlaByHead[head];
-    shouldMark = shouldMark || (safeBigTerritories && atLeastOnePla && !containsOpp[i] && !bordersNonPassAlivePlaByHead[head]);
+    bool shouldMark = numInternalSpacesMax2[i] <= 1 && !bordersNonPassAlivePlaByHead[head] && atLeastOnePla; //internal space can be 2
+    shouldMark = shouldMark || (safeBigTerritories && !containsOpp[i] && !bordersNonPassAlivePlaByHead[head] && atLeastOnePla);
     if(shouldMark) {
       Loc cur = head;
       do {
@@ -2077,7 +2066,7 @@ void Board::calculateAreaForPla(
     else {
       //Mark unsafeBigTerritories only if the opponent didn't already claim the very stones we're using to surround it as
       //pass-dead and therefore the whole thing as pass-alive-territory.
-      bool shouldMarkIfEmpty = (unsafeBigTerritories && atLeastOnePla && !containsOpp[i]);
+      bool shouldMarkIfEmpty = (unsafeBigTerritories && !containsOpp[i] && atLeastOnePla);
       if(shouldMarkIfEmpty) {
         Loc cur = head;
         do {
@@ -2624,4 +2613,13 @@ Board Board::parseBoard(int xSize, int ySize, const string& s, char lineDelimite
     }
   }
   return board;
+}
+
+bool Board::isAdjacentToPlaHead(Player pla, Loc loc, Loc plaHead) const {
+  FOREACHADJ(
+      Loc adj = loc + ADJOFFSET;
+      if(colors[adj] == pla && chain_head[adj] == plaHead)
+        return true;
+  );
+  return false;
 }

--- a/cpp/game/board.cpp
+++ b/cpp/game/board.cpp
@@ -1919,8 +1919,8 @@ void Board::calculateAreaForPla(
   };
 
   bool atLeastOnePla = false;
-  for(int y = 0; y < y_size; ++y) {
-    for(int x = 0; x < x_size; ++x) {
+  for(int y = 0; y < y_size; y++) {
+    for(int x = 0; x < x_size; x++) {
       Loc loc = Location::getLoc(x,y,x_size);
       if(regionIdxByLoc[loc] != -1)
         continue;
@@ -1949,7 +1949,7 @@ void Board::calculateAreaForPla(
           if(colors[adj] == pla) {
             Loc plaHead = chain_head[adj];
             bool alreadyPresent = false;
-            for(int j = 0; j<initialVLen; ++j) {
+            for(int j = 0; j<initialVLen; j++) {
               if(vitalForPlaHeadsLists[vStart+j] == plaHead) {
                 alreadyPresent = true;
                 break;
@@ -1986,14 +1986,14 @@ void Board::calculateAreaForPla(
 
   //Zero out vital liberties by head
   uint16_t vitalCountByPlaHead[MAX_ARR_SIZE];
-  for(int i = 0; i<numPlaHeads; ++i)
+  for(int i = 0; i<numPlaHeads; i++)
     vitalCountByPlaHead[allPlaHeads[i]] = 0;
 
-  //Walk all regions that are still bordered only by pass-alive stuff and accumulate a vital liberty to each pla it is vital for.
-  for(int i = 0; i<numRegions; ++i) {
+  //Walk all regions and accumulate a vital liberty to each pla it is vital for.
+  for(int i = 0; i<numRegions; i++) {
     int vStart = vitalStart[i];
     int vLen = vitalLen[i];
-    for(int j = 0; j<vLen; ++j) {
+    for(int j = 0; j<vLen; j++) {
       Loc plaHead = vitalForPlaHeadsLists[vStart+j];
       vitalCountByPlaHead[plaHead] += 1;
     }
@@ -2003,7 +2003,7 @@ void Board::calculateAreaForPla(
   while(true) {
     //Walk all player heads and kill them if they haven't accumulated at least 2 vital liberties
     bool killedAnything = false;
-    for(int i = 0; i<numPlaHeads; ++i) {
+    for(int i = 0; i<numPlaHeads; i++) {
       //Already killed - skip
       if(plaHasBeenKilled[i])
         continue;
@@ -2015,14 +2015,14 @@ void Board::calculateAreaForPla(
         //Walk the pla chain to update bordering regions
         Loc cur = plaHead;
         do {
-          for(int j = 0; j<4; ++j) {
+          for(int j = 0; j<4; j++) {
             Loc adj = cur + adj_offsets[j];
             Loc regionIdx = regionIdxByLoc[adj];
             if(!bordersNonPassAlivePlaByHead[regionHeads[regionIdx]] && (colors[adj] == C_EMPTY || colors[adj] == opp)){
               bordersNonPassAlivePlaByHead[regionHeads[regionIdx]] = true;
               int vStart = vitalStart[regionIdx];
               int vLen = vitalLen[regionIdx];
-              for(int k = 0; k<vLen; ++k) {
+              for(int k = 0; k<vLen; k++) {
                 Loc plaH = vitalForPlaHeadsLists[vStart+k];
                 vitalCountByPlaHead[plaH] -= 1;
               }
@@ -2032,14 +2032,13 @@ void Board::calculateAreaForPla(
         } while (cur != plaHead);
       }
     }
-
     if(!killedAnything)
       break;
   }
 
 
   //Mark result with pass-alive groups
-  for(int i = 0; i<numPlaHeads; ++i) {
+  for(int i = 0; i<numPlaHeads; i++) {
     if(!plaHasBeenKilled[i]) {
       Loc plaHead = allPlaHeads[i];
       Loc cur = plaHead;

--- a/cpp/game/board.h
+++ b/cpp/game/board.h
@@ -324,6 +324,8 @@ struct Board
     Color* result
   ) const;
 
+  bool isAdjacentToPlaHead(Player pla, Loc loc, Loc plaHead) const;
+
   void calculateIndependentLifeAreaHelper(
     const Color* basicArea,
     Color* result,


### PR DESCRIPTION
Some modifications in Benson's algorithm region building algorithm to improve efficiency.

Based on the testing (https://github.com/fuhaoda/GoProject/blob/improvedbenson/DrBombeExplore/benchmarksolutions.cpp)
It can improve efficiency and can reduce time from 10.95 seconds to 8.26 seconds in release mode.

Overall, the codes are very well written, and I have tried many small modifications without too much improvement but reduce the code readability, then I discarded those changes. The current changes are the most significant improvements without change the input/output and structures.  

Two changes.
1) add isVlenNonZero into regionBuild function to improve efficiency
2) use memset to initialize vector. The internal std::fill (the implementation is a iteration) or iteration based initialization is slower than memset when setting all the values are the same. 
3) Change the Benson's algorithm loop to reduce re-calculate vitalCountByPlaHead