### PR TITLE
Stdev ownership

### DIFF
--- a/cpp/search/search.h
+++ b/cpp/search/search.h
@@ -650,8 +650,8 @@ private:
     std::string& prefix, int64_t origVisits, int depth, const AnalysisData& data, Player perspective
   ) const;
 
-  template <typename F>
-  double getAverageTreeOwnershipHelper(std::vector<double>& accum, double minWeight, double desiredWeight, F&& func, const SearchNode* node) const;
+  template <typename Func>
+  double getAverageTreeOwnershipHelper(std::vector<double>& accum, double minWeight, double desiredWeight, Func&& preprocess, const SearchNode* node) const;
 
 };
 

--- a/cpp/search/search.h
+++ b/cpp/search/search.h
@@ -467,6 +467,7 @@ struct Search {
   //or changing parameters or clearing search.
   //If node is not providied, defaults to using the root node.
   std::vector<double> getAverageTreeOwnership(double minWeight, const SearchNode* node = NULL) const;
+  std::vector<double> getStandardDeviationTreeOwnership(double minWeight, const std::vector<double> ownership, const SearchNode* node = NULL) const;
 
   //Get ownership map as json
   nlohmann::json getJsonOwnershipMap(const Player pla, const Player perspective, const Board& board, const SearchNode* node, double ownershipMinWeight) const;
@@ -649,7 +650,8 @@ private:
     std::string& prefix, int64_t origVisits, int depth, const AnalysisData& data, Player perspective
   ) const;
 
-  double getAverageTreeOwnershipHelper(std::vector<double>& accum, double minWeight, double desiredWeight, const SearchNode* node) const;
+  template <typename F>
+  double getAverageTreeOwnershipHelper(std::vector<double>& accum, double minWeight, double desiredWeight, F&& func, const SearchNode* node) const;
 
 };
 

--- a/cpp/search/searchresults.cpp
+++ b/cpp/search/searchresults.cpp
@@ -1235,8 +1235,8 @@ vector<double> Search::getStandardDeviationTreeOwnership(double minWeight, const
   return vec;
 }
 
-template <typename F>
-double Search::getAverageTreeOwnershipHelper(vector<double>& accum, double minWeight, double desiredWeight, F&& func, const SearchNode* node) const {
+template <typename Func>
+double Search::getAverageTreeOwnershipHelper(vector<double>& accum, double minWeight, double desiredWeight, Func&& preprocess, const SearchNode* node) const {
   if(node == NULL)
     return 0;
 
@@ -1280,14 +1280,14 @@ double Search::getAverageTreeOwnershipHelper(vector<double>& accum, double minWe
     const SearchNode* child = children[i].getIfAllocated();
     assert(child != NULL);
     double desiredWeightFromChild = (double)childWeight * childWeight / relativeChildrenWeightSum * desiredWeightFromChildren;
-    actualWeightFromChildren += getAverageTreeOwnershipHelper(accum,minWeight,desiredWeightFromChild,func,child);
+    actualWeightFromChildren += getAverageTreeOwnershipHelper(accum,minWeight,desiredWeightFromChild,preprocess,child);
   }
 
   double selfWeight = desiredWeight - actualWeightFromChildren;
   float* ownerMap = nnOutput->whiteOwnerMap;
   assert(ownerMap != NULL);
   for(int pos = 0; pos<nnXLen*nnYLen; pos++)
-    accum[pos] += selfWeight * func(ownerMap[pos]);
+    accum[pos] += selfWeight * preprocess(ownerMap[pos]);
 
   return desiredWeight;
 }

--- a/cpp/search/searchresults.cpp
+++ b/cpp/search/searchresults.cpp
@@ -1217,7 +1217,7 @@ vector<double> Search::getAverageTreeOwnership(double minWeight, const SearchNod
   if(!alwaysIncludeOwnerMap)
     throw StringError("Called Search::getAverageTreeOwnership when alwaysIncludeOwnerMap is false");
   vector<double> vec(nnXLen*nnYLen,0.0);
-  getAverageTreeOwnershipHelper(vec,minWeight,1.0,[](double x) { return x; },node);
+  getAverageTreeOwnershipHelper(vec,minWeight,1.0,[](double x, int pos) { return x; },node);
   return vec;
 }
 
@@ -1225,10 +1225,10 @@ vector<double> Search::getStandardDeviationTreeOwnership(double minWeight, const
   if(node == NULL)
     node = rootNode;
   vector<double> vec(nnXLen*nnYLen,0.0);
-  getAverageTreeOwnershipHelper(vec,minWeight,1.0,[](double x) { return x * x; },node);
+  getAverageTreeOwnershipHelper(vec,minWeight,1.0,[&ownership](double x, int pos) { const double d = x - ownership[pos]; return d * d; },node);
   for(int pos = 0; pos<nnXLen*nnYLen; pos++) {
-    const double average = ownership[pos];
-    vec[pos] = sqrt(vec[pos] - average * average);
+    assert(vec[pos] >= 0.0);
+    vec[pos] = sqrt(vec[pos]);
   }
   return vec;
 }
@@ -1285,7 +1285,7 @@ double Search::getAverageTreeOwnershipHelper(vector<double>& accum, double minWe
   float* ownerMap = nnOutput->whiteOwnerMap;
   assert(ownerMap != NULL);
   for(int pos = 0; pos<nnXLen*nnYLen; pos++)
-    accum[pos] += selfWeight * preprocess(ownerMap[pos]);
+    accum[pos] += selfWeight * preprocess(ownerMap[pos], pos);
 
   return desiredWeight;
 }

--- a/cpp/search/searchresults.cpp
+++ b/cpp/search/searchresults.cpp
@@ -1224,8 +1224,6 @@ vector<double> Search::getAverageTreeOwnership(double minWeight, const SearchNod
 vector<double> Search::getStandardDeviationTreeOwnership(double minWeight, const std::vector<double> ownership, const SearchNode* node) const {
   if(node == NULL)
     node = rootNode;
-  if(!alwaysIncludeOwnerMap)
-    throw StringError("Called Search::getAverageTreeOwnership when alwaysIncludeOwnerMap is false");
   vector<double> vec(nnXLen*nnYLen,0.0);
   getAverageTreeOwnershipHelper(vec,minWeight,1.0,[](double x) { return x * x; },node);
   for(int pos = 0; pos<nnXLen*nnYLen; pos++) {


### PR DESCRIPTION
Hi.

Here is a pull request of standard deviation of ownership.

Could you check the code?
(I am not quite sure that the method name "getStandardDeviationTreeOwnership" is right...)
I hope that the template does not make performance down.

(I also changed the output format of kata-analyze on gtp mode in my private code, but I omitted it in this request since it needs larger decision.)