### PR TITLE
add friendlyMaxVisitsFactor setting

### DIFF
--- a/cpp/configs/gtp_example.cfg
+++ b/cpp/configs/gtp_example.cfg
@@ -206,6 +206,11 @@ maxVisits = 500
 # If provided, cap search time at this many seconds.
 # maxTime = 10
 
+# If provided, adapt maxVisits to averageOpponentTimePerMove * friendlyMaxVisitsFactor. (The static maxVisits setting will be ignored.)
+# Setting this to 150% of the visits/s you normally get on your hardware makes KataGo play approximately equally fast as the opponent.
+# Useful if you're running a ranked bot on a go server, and you want to be friendly if the opponent is also playing fast.
+# friendlyMaxVisitsFactor = 500
+
 # Ponder on the opponent's turn?
 ponderingEnabled = false
 maxTimePondering = 60  # Maximum time to ponder, in seconds. Comment out to make unlimited.

--- a/cpp/program/gtpconfig.cpp
+++ b/cpp/program/gtpconfig.cpp
@@ -125,6 +125,11 @@ $$MAX_PLAYOUTS
 # If provided, cap search time at this many seconds.
 $$MAX_TIME
 
+# If provided, adapt maxVisits to averageOpponentTimePerMove * friendlyMaxVisitsFactor. (The static maxVisits setting will be ignored.)
+# Setting this to 150% of the visits/s you normally get on your hardware makes KataGo play approximately equally fast as the opponent.
+# Useful if you're running a ranked bot on a go server, and you want to be friendly if the opponent is also playing fast.
+# friendlyMaxVisitsFactor = 500
+
 # Ponder on the opponent's turn?
 $$PONDERING
 # Note: you can also set "maxVisitsPondering" or "maxPlayoutsPondering" too.


### PR DESCRIPTION
Makes KataGo keep pace with the opponent by adjusting max visits
to how fast the opponent is playing.

Useful if you're running a ranked bot on a go server and want to be
friendly if the opponent is also playing fast, without sacrificing
playing strength if the opponent makes full use of the time control.

Using max visits makes the bot play naturally, responding quickly
if the move is expected and taking more time if it's unexpected.

(Of course, Katago's idea of what is obvious may differ from a human.)