### PR TITLE
adopts defaultBoardSize for benchmark

### DIFF
--- a/cpp/command/benchmark.cpp
+++ b/cpp/command/benchmark.cpp
@@ -158,7 +158,7 @@ int MainCmds::benchmark(int argc, const char* const* argv) {
   }
   else {
     if(boardSize == -1)
-      boardSize = TestCommon::DEFAULT_BENCHMARK_SGF_DATA_SIZE;
+      boardSize = cfg.contains("defaultBoardSize") ? cfg.getInt("defaultBoardSize") : TestCommon::DEFAULT_BENCHMARK_SGF_DATA_SIZE;
 
     string sgfData = TestCommon::getBenchmarkSGFData(boardSize);
     sgf = CompactSgf::parse(sgfData);


### PR DESCRIPTION
Hi.

I am not sure the original code is intentional or not, benchmark command ignores defaultBoardSize in a config file.
It means that benchmark without -boardsize option is always executed by 19x19 weight.

This pull request is a change that benchmark reads defaultBoardSize.