### PR TITLE
Fix loadsgf

### DIFF
--- a/cpp/command/gtp.cpp
+++ b/cpp/command/gtp.cpp
@@ -2614,6 +2614,7 @@ int MainCmds::gtp(const vector<string>& args) {
         int moveNumber = 0;
         if(pieces.size() == 2) {
           bool suc = Global::tryStringToInt(pieces[1],moveNumber);
+          moveNumber--;
           if(!suc || moveNumber < 0 || moveNumber > 10000000)
             parseFailed = true;
           else {


### PR DESCRIPTION
* A move number of `loadsgf`  is 1 move later one of gnugo and fuego.
* KataGo search freezes if `loadsgf` changes a board size.