### PR TITLE
Add statistical data (surprise/entropy) to training output (for later analysis)

### DIFF
--- a/cpp/dataio/trainingwrite.h
+++ b/cpp/dataio/trainingwrite.h
@@ -36,6 +36,9 @@ struct SidePosition {
   Player pla;
   int64_t unreducedNumVisits;
   std::vector<PolicyTargetMove> policyTarget;
+  float policySurprise;
+  float policyEntropy;
+  float searchEntropy;
   ValueTargets whiteValueTargets;
   NNRawStats nnRawStats;
   float targetWeight;
@@ -82,6 +85,9 @@ struct FinishedGameData {
   std::vector<float> targetWeightByTurn;
   std::vector<float> targetWeightByTurnUnrounded;
   std::vector<PolicyTarget> policyTargetsByTurn;
+  std::vector<float> policySurpriseByTurn;
+  std::vector<float> policyEntropyByTurn;
+  std::vector<float> searchEntropyByTurn;
   std::vector<ValueTargets> whiteValueTargetsByTurn; //Except this one, we may have some of
   std::vector<NNRawStats> nnRawStatsByTurn;
   Color* finalFullArea;
@@ -158,7 +164,9 @@ struct TrainingWriteBuffers {
   //C27: Weight assigned to the final board ownership target and score distr targets. Most training rows will have this be 1, some will be 0.
   //C28: Weight assigned to the next move policy target
   //C29: Weight assigned to the lead target
-  //C30-32: Unused
+  //C30: Policy Surprise (for statistical purposes)
+  //C31: Policy Entropy (for statistical purposes)
+  //C32: Search Entropy (for statistical purposes)
   //C33: Weight assigned to the future position targets valueTargetsNCHW C1-C2
   //C34: Weight assigned to the area/territory target valueTargetsNCHW C4
   //C35: Unused
@@ -231,6 +239,9 @@ struct TrainingWriteBuffers {
     int64_t unreducedNumVisits,
     const std::vector<PolicyTargetMove>* policyTarget0, //can be null
     const std::vector<PolicyTargetMove>* policyTarget1, //can be null
+    float policySurprise,
+    float policyEntropy,
+    float searchEntropy,
     const std::vector<ValueTargets>& whiteValueTargets,
     int whiteValueTargetsIdx, //index in whiteValueTargets corresponding to this turn.
     const NNRawStats& nnRawStats,

--- a/cpp/search/search.h
+++ b/cpp/search/search.h
@@ -308,6 +308,7 @@ struct Search {
   //Get the surprisingness (kl-divergence) of the search result given the policy prior, as well as the entropy of each.
   //Returns false if could not be computed.
   bool getPolicySurpriseAndEntropy(double& surpriseRet, double& searchEntropyRet, double& policyEntropyRet) const;
+  bool getPolicySurpriseAndEntropy(double& surpriseRet, double& searchEntropyRet, double& policyEntropyRet, const SearchNode* node) const;
   double getPolicySurprise() const;
 
   void printPV(std::ostream& out, const SearchNode* node, int maxDepth) const;

--- a/cpp/search/searchresults.cpp
+++ b/cpp/search/searchresults.cpp
@@ -463,11 +463,15 @@ double Search::getPolicySurprise() const {
   return 0.0;
 }
 
-//Safe to call concurrently with search
 bool Search::getPolicySurpriseAndEntropy(double& surpriseRet, double& searchEntropyRet, double& policyEntropyRet) const {
-  if(rootNode == NULL)
+  return getPolicySurpriseAndEntropy(surpriseRet, searchEntropyRet, policyEntropyRet, rootNode);
+}
+
+//Safe to call concurrently with search
+bool Search::getPolicySurpriseAndEntropy(double& surpriseRet, double& searchEntropyRet, double& policyEntropyRet, const SearchNode* node) const {
+  if(node == NULL)
     return false;
-  const NNOutput* nnOutput = rootNode->getNNOutput();
+  const NNOutput* nnOutput = node->getNNOutput();
   if(nnOutput == NULL)
     return false;
 
@@ -478,7 +482,7 @@ bool Search::getPolicySurpriseAndEntropy(double& surpriseRet, double& searchEntr
   double lcbBuf[NNPos::MAX_NN_POLICY_SIZE];
   double radiusBuf[NNPos::MAX_NN_POLICY_SIZE];
   bool suc = getPlaySelectionValues(
-    *rootNode,locs,playSelectionValues,NULL,1.0,allowDirectPolicyMoves,alwaysComputeLcb,false,lcbBuf,radiusBuf
+    *node,locs,playSelectionValues,NULL,1.0,allowDirectPolicyMoves,alwaysComputeLcb,false,lcbBuf,radiusBuf
   );
   if(!suc)
     return false;
@@ -490,12 +494,12 @@ bool Search::getPolicySurpriseAndEntropy(double& surpriseRet, double& searchEntr
   }
 
   double sumPlaySelectionValues = 0.0;
-  for(int i = 0; i<playSelectionValues.size(); i++)
+  for(size_t i = 0; i < playSelectionValues.size(); i++)
     sumPlaySelectionValues += playSelectionValues[i];
 
   double surprise = 0.0;
   double searchEntropy = 0.0;
-  for(int i = 0; i<playSelectionValues.size(); i++) {
+  for(size_t i = 0; i < playSelectionValues.size(); i++) {
     int pos = getPos(locs[i]);
     double policy = std::max((double)policyProbsFromNNBuf[pos],1e-100);
     double target = playSelectionValues[i] / sumPlaySelectionValues;


### PR DESCRIPTION
This PR records the surprise and entropy for every turn into the training output (unused outputs C30-32), rather than making some sort of aggregate average.  If I recorded it to the wrong place, please let me know and I'll adjust it!