### PR TITLE
More utf8

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -365,6 +365,10 @@ if(MSVC)
   # core/rand.cpp uses winsock for a gethostname
   target_link_libraries(katago ws2_32)
 
+  # Go ahead and suppress some MSVC warnings about sprintf and similar
+  # things. They might be useful in some cases, but also are noisy.
+  target_compile_definitions(katago PRIVATE _CRT_SECURE_NO_WARNINGS)
+
   if(USE_AVX2)
     set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} /arch:AVX2 -D__FMA__")
     target_compile_definitions(katago PRIVATE USE_AVX2)

--- a/cpp/book/book.cpp
+++ b/cpp/book/book.cpp
@@ -1466,7 +1466,7 @@ void Book::recomputeNodeCost(BookNode* node) {
     );
 
     // If we have more than 1/N of unexpanded policy, we cap the penalty for expanded moves at N.
-    double movesExpanded = node->moves.size();
+    double movesExpanded = (double)node->moves.size();
     if(movesExpanded > 1.0 / (rawPolicy + 1e-30)) {
       movesExpanded = 1.0 / (rawPolicy + 1e-30);
     }
@@ -1589,7 +1589,7 @@ void Book::recomputeNodeCost(BookNode* node) {
     // If there's an unusually large share of the policy not expanded, add a mild bonus for it.
     // For the final node expansion cost, sharp score discrepancy beyond 1 point is not capped, to encourage expanding the
     // search to better resolve the difference, since sharp score can have some weird outliers.
-    double movesExpanded = node->moves.size();
+    double movesExpanded = (double)node->moves.size();
     double excessUnexpandedPolicy = 0.0;
     if(movesExpanded > 0 && node->thisValuesNotInBook.maxPolicy > 1.0 / movesExpanded)
       excessUnexpandedPolicy = node->thisValuesNotInBook.maxPolicy - 1.0 / movesExpanded;
@@ -1828,7 +1828,7 @@ void Book::exportToHtmlDir(
     std::set<Loc> locsHandled;
 
     dataVarsStr += "const moves = [";
-    for(int idx: uniqueMoveIdxs) {
+    for(size_t idx: uniqueMoveIdxs) {
       dataVarsStr += "{";
       const Loc passLoc = Board::PASS_LOC;
       if(uniqueMovesInBook[idx].move != passLoc) {

--- a/cpp/command/genbook.cpp
+++ b/cpp/command/genbook.cpp
@@ -428,7 +428,7 @@ int MainCmds::genbook(const vector<string>& args) {
 
     nodeValues.maxPolicy = maxPolicy;
     nodeValues.weight = remainingSearchValues.weight;
-    nodeValues.visits = remainingSearchValues.visits;
+    nodeValues.visits = (double)remainingSearchValues.visits;
   };
 
 

--- a/cpp/command/misc.cpp
+++ b/cpp/command/misc.cpp
@@ -1273,7 +1273,7 @@ int MainCmds::dataminesgfs(const vector<string>& args) {
     const bool preventEncore = true;
     const vector<Move>& sgfMoves = sgf->moves;
 
-    if(sgfMoves.size() > maxDepth) {
+    if((int64_t)sgfMoves.size() > maxDepth) {
       numFilteredSgfs.fetch_add(1);
       return;
     }

--- a/cpp/core/mainargs.cpp
+++ b/cpp/core/mainargs.cpp
@@ -31,3 +31,98 @@ std::vector<std::string> MainArgs::getCommandLineArgsUTF8(int argc, const char* 
   return args;
 #endif
 }
+
+#ifdef OS_IS_WINDOWS
+
+// Converts utf8 used in the rest of the program to windows wide char encoding
+// just before output to console.
+class ConsoleStreamBufWindows : public std::streambuf {
+public:
+  ConsoleStreamBufWindows(DWORD handleId);
+
+protected:
+  virtual int sync();
+  virtual int_type overflow(int_type c = traits_type::eof());
+
+private:
+  const HANDLE handle;
+  std::string buf;
+  bool isConsole;
+};
+
+ConsoleStreamBufWindows::ConsoleStreamBufWindows(DWORD handleId)
+  : handle(GetStdHandle(handleId)),
+    buf()
+{
+  DWORD lpMode;
+  // Check if we are a console or not so that we know whether to call
+  // WriteConsole or not, as mentioned in
+  // https://docs.microsoft.com/en-us/windows/console/writeconsole
+  // Stdout and Stderr could be a file if redirected in the windows terminal.
+  bool success = GetConsoleMode(handle, &lpMode);
+  if(success)
+    isConsole = true;
+  else
+    isConsole = false;
+}
+
+int ConsoleStreamBufWindows::sync()
+{
+  if(buf.empty())
+    return 0;
+
+  if(isConsole) {
+    std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+    std::wstring toWrite = converter.from_bytes(buf);
+    while(toWrite.size() > 0) {
+      //DWORD is 32 bits, size_t is often larger.
+      DWORD sizeToWrite = (DWORD)std::min((size_t)0xFFFFFFFFU,toWrite.size());
+
+      DWORD writtenSize;
+      bool success = WriteConsoleW(handle, toWrite.c_str(), sizeToWrite, &writtenSize, NULL);
+      if(!success)
+        break;
+
+      if((size_t)writtenSize >= toWrite.size())
+        break;
+      toWrite = toWrite.substr((size_t)writtenSize);
+    }
+  }
+  else {
+    // Just write raw utf8 to file, no conversion.
+    while(buf.size() > 0) {
+      //DWORD is 32 bits, size_t is often larger.
+      DWORD sizeToWrite = (DWORD)std::min((size_t)0xFFFFFFFFU,buf.size());
+
+      DWORD writtenSize;
+      bool success = WriteFile(handle, buf.c_str(), sizeToWrite, &writtenSize, NULL);
+      if(!success)
+        break;
+
+      if((size_t)writtenSize >= buf.size())
+        break;
+      buf = buf.substr((size_t)writtenSize);
+    }
+  }
+
+  buf.clear();
+  return 0;
+}
+
+ConsoleStreamBufWindows::int_type ConsoleStreamBufWindows::overflow(int_type c)
+{
+  buf += traits_type::to_char_type(c);
+  return traits_type::not_eof(c);
+}
+
+void MainArgs::makeCoutAndCerrAcceptUTF8() {
+  if(GetFileType(GetStdHandle(STD_OUTPUT_HANDLE)) == FILE_TYPE_CHAR)
+    std::cout.rdbuf(new ConsoleStreamBufWindows(STD_OUTPUT_HANDLE));
+  if(GetFileType(GetStdHandle(STD_ERROR_HANDLE)) == FILE_TYPE_CHAR)
+    std::cerr.rdbuf(new ConsoleStreamBufWindows(STD_ERROR_HANDLE));
+}
+#else
+void MainArgs::makeCoutAndCerrAcceptUTF8() {
+  // For non-windows, do nothing, assume they already are happy with utf8
+}
+#endif

--- a/cpp/core/mainargs.h
+++ b/cpp/core/mainargs.h
@@ -5,6 +5,8 @@
 
 namespace MainArgs {
   std::vector<std::string> getCommandLineArgsUTF8(int argc, const char* const* argv);
+
+  void makeCoutAndCerrAcceptUTF8();
 }
 
 #endif

--- a/cpp/core/rand.cpp
+++ b/cpp/core/rand.cpp
@@ -507,8 +507,8 @@ void Rand::runTests() {
     out << Hash::murmurMix(12345) << endl;
     out << Hash::murmurMix(298174913) << endl;
     out << Hash::splitMix64(1234567) << endl;
-    out << Hash::splitMix64(1234567 + (uint64_t)0x9e3779b97f4a7c15ULL) << endl;
-    out << Hash::splitMix64(1234567 + 2*(uint64_t)0x9e3779b97f4a7c15ULL) << endl;
+    out << Hash::splitMix64((uint64_t)1234567 + (uint64_t)0x9e3779b97f4a7c15ULL) << endl;
+    out << Hash::splitMix64((uint64_t)1234567 + (uint64_t)2*(uint64_t)0x9e3779b97f4a7c15ULL) << endl;
     out << Global::uint64ToHexString(Hash::rrmxmx(0)) << endl;
     out << Global::uint64ToHexString(Hash::rrmxmx(1)) << endl;
     out << Global::uint64ToHexString(Hash::rrmxmx(0x0123456789abcdefULL)) << endl;

--- a/cpp/dataio/homedata.cpp
+++ b/cpp/dataio/homedata.cpp
@@ -15,6 +15,7 @@
 // even though PathRemoveFileSpecW is deprecated, it should still work.
 // #include <pathcch.h>
 // #pragma comment(lib, "pathcch.lib")
+#include <codecvt>
 #endif
 
 #include "../core/makedir.h"
@@ -38,14 +39,9 @@ vector<string> HomeData::getDefaultFilesDirs() {
   // #else
   PathRemoveFileSpecW(buf);
   // #endif
-  constexpr size_t buf2Size = (bufSize+1) * 2;
-  char buf2[buf2Size];
-  size_t ret;
-  wcstombs_s(&ret, buf2, buf2Size, buf, buf2Size-1);
-
-  string executableDir(buf2);
   vector<string> dirs;
-  dirs.push_back(executableDir);
+  std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+  dirs.push_back(converter.to_bytes(buf));
   return dirs;
 }
 
@@ -74,12 +70,9 @@ string HomeData::getHomeDataDir(bool makeDir, const string& homeDataDirOverride)
   // #else
   PathRemoveFileSpecW(buf);
   // #endif
-  constexpr size_t buf2Size = (bufSize+1) * 2;
-  char buf2[buf2Size];
-  size_t ret;
-  wcstombs_s(&ret, buf2, buf2Size, buf, buf2Size-1);
 
-  string homeDataDir(buf2);
+  std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+  string homeDataDir = converter.to_bytes(buf);
   homeDataDir += "/KataGoData";
   if(makeDir) MakeDir::make(homeDataDir);
   return homeDataDir;

--- a/cpp/dataio/sgf.cpp
+++ b/cpp/dataio/sgf.cpp
@@ -290,7 +290,7 @@ int64_t Sgf::depth() const {
     if(childDepth > maxChildDepth)
       maxChildDepth = childDepth;
   }
-  return maxChildDepth + nodes.size();
+  return maxChildDepth + (int64_t)nodes.size();
 }
 
 int64_t Sgf::nodeCount() const {
@@ -307,7 +307,7 @@ int64_t Sgf::branchCount() const {
     count += children[i]->branchCount();
   }
   if(children.size() > 1)
-    count += children.size()-1;
+    count += (int64_t)children.size()-1;
   return count;
 }
 
@@ -828,13 +828,13 @@ static uint64_t parseHex64(const string& str) {
 
 set<Hash128> Sgf::readExcludes(const vector<string>& files) {
   set<Hash128> excludeHashes;
-  for(int i = 0; i<files.size(); i++) {
-    string excludeHashesFile = Global::trim(files[i]);
+  for(const string& file: files) {
+    string excludeHashesFile = Global::trim(file);
     if(excludeHashesFile.size() <= 0)
       continue;
     vector<string> hashes = FileUtils::readFileLines(excludeHashesFile,'\n');
-    for(int64_t j = 0; j < hashes.size(); j++) {
-      const string& hash128 = Global::trim(Global::stripComments(hashes[j]));
+    for(const string& hashStr: hashes) {
+      string hash128 = Global::trim(Global::stripComments(hashStr));
       if(hash128.length() <= 0)
         continue;
       if(hash128.length() != 32)
@@ -1395,7 +1395,7 @@ void CompactSgf::setupInitialBoardAndHist(const Rules& initialRules, Board& boar
 }
 
 void CompactSgf::playMovesAssumeLegal(Board& board, Player& nextPla, BoardHistory& hist, int64_t turnIdx) const {
-  if(turnIdx < 0 || turnIdx > moves.size())
+  if(turnIdx < 0 || turnIdx > (int64_t)moves.size())
     throw StringError(
       Global::strprintf(
         "Attempting to set up position from SGF for invalid turn idx %lld, valid values are %lld to %lld",
@@ -1410,7 +1410,7 @@ void CompactSgf::playMovesAssumeLegal(Board& board, Player& nextPla, BoardHistor
 }
 
 void CompactSgf::playMovesTolerant(Board& board, Player& nextPla, BoardHistory& hist, int64_t turnIdx, bool preventEncore) const {
-  if(turnIdx < 0 || turnIdx > moves.size())
+  if(turnIdx < 0 || turnIdx > (int64_t)moves.size())
     throw StringError(
       Global::strprintf(
         "Attempting to set up position from SGF for invalid turn idx %lld, valid values are %lld to %lld",

--- a/cpp/game/boardhistory.cpp
+++ b/cpp/game/boardhistory.cpp
@@ -315,7 +315,7 @@ void BoardHistory::clear(const Board& board, Player pla, const Rules& r, int ePh
     int netWhiteCaptures = board.numWhiteCaptures - board.numBlackCaptures;
     whiteBonusScore -= (float)netWhiteCaptures;
   }
-  whiteHandicapBonusScore = computeWhiteHandicapBonus();
+  whiteHandicapBonusScore = (float)computeWhiteHandicapBonus();
 }
 
 void BoardHistory::setInitialTurnNumber(int n) {
@@ -324,7 +324,7 @@ void BoardHistory::setInitialTurnNumber(int n) {
 
 void BoardHistory::setAssumeMultipleStartingBlackMovesAreHandicap(bool b) {
   assumeMultipleStartingBlackMovesAreHandicap = b;
-  whiteHandicapBonusScore = computeWhiteHandicapBonus();
+  whiteHandicapBonusScore = (float)computeWhiteHandicapBonus();
 }
 
 static int numHandicapStonesOnBoardHelper(const Board& board, int blackNonPassTurnsToStart) {
@@ -1006,7 +1006,7 @@ void BoardHistory::makeBoardMoveAssumeLegal(Board& board, Loc moveLoc, Player mo
   if(movePla == P_WHITE && moveLoc != Board::PASS_LOC)
     whiteHasMoved = true;
   if(assumeMultipleStartingBlackMovesAreHandicap && !whiteHasMoved && movePla == P_BLACK && rules.whiteHandicapBonusRule != Rules::WHB_ZERO) {
-    whiteHandicapBonusScore = computeWhiteHandicapBonus();
+    whiteHandicapBonusScore = (float)computeWhiteHandicapBonus();
   }
 
   //Phase transitions and game end

--- a/cpp/game/boardhistory.h
+++ b/cpp/game/boardhistory.h
@@ -22,7 +22,7 @@ struct BoardHistory {
   std::vector<Hash128> koHashHistory;
   //The index of the first turn for which we have a koHashHistory (since depending on rules, passes may clear it).
   //Index 0 = starting state, index 1 = state after move 0, index 2 = state after move 1, etc...
-  int firstTurnIdxWithKoHistory;
+  size_t firstTurnIdxWithKoHistory;
 
   //The board and player to move as of the very start, before moveHistory.
   Board initialBoard;
@@ -182,7 +182,7 @@ private:
 struct KoHashTable {
   uint32_t* idxTable;
   std::vector<Hash128> koHashHistorySortedByLowBits;
-  int firstTurnIdxWithKoHistory;
+  size_t firstTurnIdxWithKoHistory;
 
   static const int TABLE_SIZE = 1 << 10;
   static const uint64_t TABLE_MASK = TABLE_SIZE-1;

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -156,6 +156,7 @@ static int handleSubcommand(const string& subcommand, const vector<string>& args
 
 int main(int argc, const char* const* argv) {
   vector<string> args = MainArgs::getCommandLineArgsUTF8(argc,argv);
+  MainArgs::makeCoutAndCerrAcceptUTF8();
 
   if(args.size() < 2) {
     printHelp(args);

--- a/cpp/neuralnet/openclbackend.cpp
+++ b/cpp/neuralnet/openclbackend.cpp
@@ -84,6 +84,8 @@ static void checkBufferSize(int batchSize, int nnXLen, int nnYLen, int channels)
 //---------------------------------------------------------------------------------------------------------
 
 void NeuralNet::globalInitialize() {
+  // If int is only 2 bytes, this implementation won't work right now.
+  static_assert(sizeof(int) >= 4, "");
 }
 
 void NeuralNet::globalCleanup() {
@@ -855,8 +857,8 @@ struct ConvLayer {
       int outTileXSize = convXSize == 3 ? handle->tuneParams.conv3x3.OUTTILE_XSIZE : handle->tuneParams.conv5x5.OUTTILE_XSIZE;
       int outTileYSize = convYSize == 3 ? handle->tuneParams.conv3x3.OUTTILE_YSIZE : handle->tuneParams.conv5x5.OUTTILE_YSIZE;
 
-      int outChannelsPadded = roundUpToMultiple(outChannels, handle->getXGemmNPaddingMult());
-      int inChannelsPadded = roundUpToMultiple(inChannels, handle->getXGemmKPaddingMult());
+      int outChannelsPadded = roundUpToMultipleInt(outChannels, handle->getXGemmNPaddingMult());
+      int inChannelsPadded = roundUpToMultipleInt(inChannels, handle->getXGemmKPaddingMult());
 
       numTilesX = (nnXLen + outTileXSize - 1) / outTileXSize;
       numTilesY = (nnYLen + outTileYSize - 1) / outTileYSize;
@@ -964,9 +966,9 @@ struct ConvLayer {
   }
 
   ConvWorkspaceEltsNeeded requiredConvWorkspaceElts(ComputeHandleInternal* handle, size_t maxBatchSize) const {
-    int numTilesTotalPadded = roundUpToMultiple(maxBatchSize * numTilesX * numTilesY, handle->getXGemmMPaddingMult());
-    int outChannelsPadded = roundUpToMultiple(outChannels, handle->getXGemmNPaddingMult());
-    int inChannelsPadded = roundUpToMultiple(inChannels, handle->getXGemmKPaddingMult());
+    int numTilesTotalPadded = roundUpToMultipleInt(maxBatchSize * numTilesX * numTilesY, handle->getXGemmMPaddingMult());
+    int outChannelsPadded = roundUpToMultipleInt(outChannels, handle->getXGemmNPaddingMult());
+    int inChannelsPadded = roundUpToMultipleInt(inChannels, handle->getXGemmKPaddingMult());
     return
       ConvWorkspaceEltsNeeded(
         numTilesTotalPadded * inChannelsPadded * inTileXYSize,
@@ -1020,9 +1022,9 @@ struct ConvLayer {
       }
 
       {
-        int numTilesTotalPadded = roundUpToMultiple(batchSize * numTilesX * numTilesY, handle->getXGemmMPaddingMult());
-        int outChannelsPadded = roundUpToMultiple(outChannels, handle->getXGemmNPaddingMult());
-        int inChannelsPadded = roundUpToMultiple(inChannels, handle->getXGemmKPaddingMult());
+        int numTilesTotalPadded = roundUpToMultipleInt(batchSize * numTilesX * numTilesY, handle->getXGemmMPaddingMult());
+        int outChannelsPadded = roundUpToMultipleInt(outChannels, handle->getXGemmNPaddingMult());
+        int inChannelsPadded = roundUpToMultipleInt(inChannels, handle->getXGemmKPaddingMult());
 
         cl_int err;
         MAYBE_EVENT;
@@ -1159,9 +1161,9 @@ struct ConvLayer {
       }
 
       {
-        int numTilesTotalPadded = roundUpToMultiple(batchSize * numTilesX * numTilesY, handle->getXGemmMPaddingMult());
-        int outChannelsPadded = roundUpToMultiple(outChannels, handle->getXGemmNPaddingMult());
-        int inChannelsPadded = roundUpToMultiple(inChannels, handle->getXGemmKPaddingMult());
+        int numTilesTotalPadded = roundUpToMultipleInt(batchSize * numTilesX * numTilesY, handle->getXGemmMPaddingMult());
+        int outChannelsPadded = roundUpToMultipleInt(outChannels, handle->getXGemmNPaddingMult());
+        int inChannelsPadded = roundUpToMultipleInt(inChannels, handle->getXGemmKPaddingMult());
 
         cl_int err;
         MAYBE_EVENT;

--- a/cpp/neuralnet/openclhelpers.h
+++ b/cpp/neuralnet/openclhelpers.h
@@ -113,6 +113,7 @@ namespace OpenCLHelpers {
 
   size_t powerOf2ify(size_t size);
   size_t roundUpToMultiple(size_t size, size_t ofThis);
+  int roundUpToMultipleInt(size_t size, size_t ofThis);
 
   cl_int doBatchedXGemm_KM_KN_NM(
     cl_kernel kernel,

--- a/cpp/neuralnet/opencltuner.cpp
+++ b/cpp/neuralnet/opencltuner.cpp
@@ -653,8 +653,8 @@ static void shuffleConfigs(
   Rand rand;
   if(configs.size() == 0)
     return;
-  for(int i = configs.size()-1; i > 0; i--) {
-    int j = rand.nextUInt(i+1);
+  for(size_t i = configs.size()-1; i > 0; i--) {
+    size_t j = (size_t)rand.nextUInt64(i+1);
     std::swap(configs[i],configs[j]);
   }
 }
@@ -1113,9 +1113,9 @@ static bool tuneXGemm(
     maxChannels = std::max(modelInfo.regularNumChannels,maxChannels);
     maxChannels = std::max(modelInfo.gpoolNumChannels,maxChannels);
 
-    int numTilesTotalPadded = roundUpToMultiple(numTilesTotal,cfg.xGemm.MWG);
-    int maxOutChannelsPadded = roundUpToMultiple(maxChannels,cfg.xGemm.NWG);
-    int maxInChannelsPadded = roundUpToMultiple(maxChannels,cfg.xGemm.KWG);
+    int numTilesTotalPadded = roundUpToMultipleInt(numTilesTotal,cfg.xGemm.MWG);
+    int maxOutChannelsPadded = roundUpToMultipleInt(maxChannels,cfg.xGemm.NWG);
+    int maxInChannelsPadded = roundUpToMultipleInt(maxChannels,cfg.xGemm.KWG);
 
     int outNumFloats = numTilesTotalPadded * maxOutChannelsPadded * inTileXYSize;
     cl_mem input;
@@ -1152,8 +1152,8 @@ static bool tuneXGemm(
       default: ASSERT_UNREACHABLE; break;
       }
 
-      int outChannelsPadded = roundUpToMultiple(outChannels, cfg.xGemm.NWG);
-      int inChannelsPadded = roundUpToMultiple(inChannels, cfg.xGemm.KWG);
+      int outChannelsPadded = roundUpToMultipleInt(outChannels, cfg.xGemm.NWG);
+      int inChannelsPadded = roundUpToMultipleInt(inChannels, cfg.xGemm.KWG);
 
       cl_event event;
       err = doBatchedXGemm_KM_KN_NM(
@@ -1342,9 +1342,9 @@ static bool tuneXGemm16(
     maxChannels = std::max(modelInfo.regularNumChannels,maxChannels);
     maxChannels = std::max(modelInfo.gpoolNumChannels,maxChannels);
 
-    int numTilesTotalPadded = roundUpToMultiple(numTilesTotal,cfg.xGemm16.MWG);
-    int maxOutChannelsPadded = roundUpToMultiple(maxChannels,cfg.xGemm16.NWG);
-    int maxInChannelsPadded = roundUpToMultiple(maxChannels,cfg.xGemm16.KWG);
+    int numTilesTotalPadded = roundUpToMultipleInt(numTilesTotal,cfg.xGemm16.MWG);
+    int maxOutChannelsPadded = roundUpToMultipleInt(maxChannels,cfg.xGemm16.NWG);
+    int maxInChannelsPadded = roundUpToMultipleInt(maxChannels,cfg.xGemm16.KWG);
 
     int outNumFloats = numTilesTotalPadded * maxOutChannelsPadded * inTileXYSize;
     cl_mem input = randomReadOnly3dPaddedBufferHalf(
@@ -1369,8 +1369,8 @@ static bool tuneXGemm16(
       default: ASSERT_UNREACHABLE; break;
       }
 
-      int outChannelsPadded = roundUpToMultiple(outChannels, cfg.xGemm16.NWG);
-      int inChannelsPadded = roundUpToMultiple(inChannels, cfg.xGemm16.KWG);
+      int outChannelsPadded = roundUpToMultipleInt(outChannels, cfg.xGemm16.NWG);
+      int inChannelsPadded = roundUpToMultipleInt(inChannels, cfg.xGemm16.KWG);
 
       cl_event event;
       err = doBatchedXGemm_KM_KN_NM(
@@ -1539,9 +1539,9 @@ static bool tuneHGemmWmma(
     maxChannels = std::max(modelInfo.regularNumChannels,maxChannels);
     maxChannels = std::max(modelInfo.gpoolNumChannels,maxChannels);
 
-    int numTilesTotalPadded = roundUpToMultiple(numTilesTotal,cfg.hGemmWmma.MWG);
-    int maxOutChannelsPadded = roundUpToMultiple(maxChannels,cfg.hGemmWmma.NWG);
-    int maxInChannelsPadded = roundUpToMultiple(maxChannels,cfg.hGemmWmma.KWG);
+    int numTilesTotalPadded = roundUpToMultipleInt(numTilesTotal,cfg.hGemmWmma.MWG);
+    int maxOutChannelsPadded = roundUpToMultipleInt(maxChannels,cfg.hGemmWmma.NWG);
+    int maxInChannelsPadded = roundUpToMultipleInt(maxChannels,cfg.hGemmWmma.KWG);
 
     int outNumFloats = numTilesTotalPadded * maxOutChannelsPadded * inTileXYSize;
     cl_mem input = randomReadOnly3dPaddedBufferHalf(
@@ -1566,8 +1566,8 @@ static bool tuneHGemmWmma(
       default: ASSERT_UNREACHABLE; break;
       }
 
-      int outChannelsPadded = roundUpToMultiple(outChannels, cfg.hGemmWmma.NWG);
-      int inChannelsPadded = roundUpToMultiple(inChannels, cfg.hGemmWmma.KWG);
+      int outChannelsPadded = roundUpToMultipleInt(outChannels, cfg.hGemmWmma.NWG);
+      int inChannelsPadded = roundUpToMultipleInt(inChannels, cfg.hGemmWmma.KWG);
 
       cl_event event;
       err = doBatchedHGemmWmma_KM_KN_NM(
@@ -1710,7 +1710,7 @@ static void tuneTransform(
     int kPaddingMult = cfg.getXGemmKPaddingMult(cfg.shouldUseFP16Compute, cfg.shouldUseFP16TensorCores);
 
     int inputNumFloats = batchSize * nnXLen * nnYLen * maxChannels;
-    int outputNumFloats = roundUpToMultiple(numTilesTotal,mPaddingMult) * roundUpToMultiple(maxChannels,kPaddingMult) * inTileXSize * inTileYSize;
+    int outputNumFloats = roundUpToMultipleInt(numTilesTotal,mPaddingMult) * roundUpToMultipleInt(maxChannels,kPaddingMult) * inTileXSize * inTileYSize;
 
     cl_mem input;
     cl_mem output;
@@ -1873,7 +1873,7 @@ static void tuneUntransform(
     int nPaddingMult = cfg.getXGemmNPaddingMult(cfg.shouldUseFP16Compute, cfg.shouldUseFP16TensorCores);
     //int kPaddingMult = cfg.getXGemmKPaddingMult(cfg.shouldUseFP16Compute, cfg.shouldUseFP16TensorCores);
 
-    int inputNumFloats = roundUpToMultiple(numTilesTotal,mPaddingMult) * roundUpToMultiple(maxChannels,nPaddingMult) * inTileXSize * inTileYSize;
+    int inputNumFloats = roundUpToMultipleInt(numTilesTotal,mPaddingMult) * roundUpToMultipleInt(maxChannels,nPaddingMult) * inTileXSize * inTileYSize;
     int outputNumFloats = batchSize * nnXLen * nnYLen * maxChannels;
 
     cl_mem input;

--- a/cpp/program/playutils.cpp
+++ b/cpp/program/playutils.cpp
@@ -643,7 +643,7 @@ double PlayUtils::getSearchFactor(
   double searchFactor = 1.0;
   if(recentWinLossValues.size() >= 3 && params.winLossUtilityFactor - searchFactorWhenWinningThreshold > 1e-10) {
     double recentLeastWinning = pla == P_BLACK ? -params.winLossUtilityFactor : params.winLossUtilityFactor;
-    for(int i = recentWinLossValues.size()-3; i < recentWinLossValues.size(); i++) {
+    for(size_t i = recentWinLossValues.size()-3; i < recentWinLossValues.size(); i++) {
       if(pla == P_BLACK && recentWinLossValues[i] > recentLeastWinning)
         recentLeastWinning = recentWinLossValues[i];
       if(pla == P_WHITE && recentWinLossValues[i] < recentLeastWinning)
@@ -681,7 +681,7 @@ vector<double> PlayUtils::computeOwnership(
   bot->runWholeSearch(pla);
 
   int64_t minVisitsForOwnership = 2;
-  vector<double> ownerships = bot->getAverageTreeOwnership(minVisitsForOwnership);
+  vector<double> ownerships = bot->getAverageTreeOwnership((double)minVisitsForOwnership);
 
   bot->setParams(oldParams);
   bot->setAlwaysIncludeOwnerMap(oldAlwaysIncludeOwnerMap);
@@ -1007,9 +1007,9 @@ Rules PlayUtils::genRandomRules(Rand& rand) {
   vector<int> allowedTaxRules = { Rules::TAX_NONE, Rules::TAX_SEKI, Rules::TAX_ALL };
 
   Rules rules;
-  rules.koRule = allowedKoRules[rand.nextUInt(allowedKoRules.size())];
-  rules.scoringRule = allowedScoringRules[rand.nextUInt(allowedScoringRules.size())];
-  rules.taxRule = allowedTaxRules[rand.nextUInt(allowedTaxRules.size())];
+  rules.koRule = allowedKoRules[rand.nextUInt((uint32_t)allowedKoRules.size())];
+  rules.scoringRule = allowedScoringRules[rand.nextUInt((uint32_t)allowedScoringRules.size())];
+  rules.taxRule = allowedTaxRules[rand.nextUInt((uint32_t)allowedTaxRules.size())];
   rules.multiStoneSuicideLegal = rand.nextBool(0.5);
 
   if(rules.scoringRule == Rules::SCORING_AREA)

--- a/cpp/search/search.cpp
+++ b/cpp/search/search.cpp
@@ -3225,7 +3225,7 @@ void Search::maybeRecomputeExistingNNOutput(
     //We accept this and tolerate that for a few iterations potentially we will be using the OLD policy - without noise,
     //or without root temperature, etc.
     //Or if we have none of those things, then we'll not end up updating anything except the age, which is okay too.
-    int oldAge = node.nodeAge.exchange(searchNodeAge,std::memory_order_acq_rel);
+    uint32_t oldAge = node.nodeAge.exchange(searchNodeAge,std::memory_order_acq_rel);
     if(oldAge < searchNodeAge) {
       NNOutput* nnOutput = node.getNNOutput();
       assert(nnOutput != NULL);

--- a/cpp/search/searchresults.cpp
+++ b/cpp/search/searchresults.cpp
@@ -99,7 +99,7 @@ bool Search::getPlaySelectionValues(
     }
   }
 
-  int numChildren = playSelectionValues.size();
+  int numChildren = (int)playSelectionValues.size();
 
   //Find the best child by weight
   int mostWeightedIdx = 0;
@@ -288,8 +288,9 @@ void Search::maybeRecomputeNormToTApproxTable() {
 }
 
 double Search::getNormToTApproxForLCB(int64_t numVisits) const {
-  int64_t idx = numVisits-MIN_VISITS_FOR_LCB;
-  assert(idx >= 0);
+  assert(numVisits >= MIN_VISITS_FOR_LCB);
+  uint64_t idx = (uint64_t)(numVisits - MIN_VISITS_FOR_LCB);
+  assert(normToTApproxTable.size() > 0);
   if(idx >= normToTApproxTable.size())
     idx = normToTApproxTable.size()-1;
   return normToTApproxTable[idx];
@@ -465,7 +466,7 @@ Loc Search::getChosenMoveLoc() {
     searchParams.chosenMoveTemperatureHalflife, searchParams.chosenMoveTemperatureEarly, searchParams.chosenMoveTemperature
   );
 
-  uint32_t idxChosen = chooseIndexWithTemperature(nonSearchRand, playSelectionValues.data(), playSelectionValues.size(), temperature);
+  uint32_t idxChosen = chooseIndexWithTemperature(nonSearchRand, playSelectionValues.data(), (int)playSelectionValues.size(), temperature);
   return locs[idxChosen];
 }
 
@@ -934,7 +935,7 @@ void Search::getAnalysisData(
         break;
       children.push_back(child);
     }
-    numChildren = children.size();
+    numChildren = (int)children.size();
 
     if(numChildren <= 0)
       return;
@@ -1252,7 +1253,7 @@ void Search::printTreeHelper(
   bool duplicateForSymmetries = false;
   getAnalysisData(node,analysisData,0,true,options.maxPVDepth_,duplicateForSymmetries);
 
-  int numChildren = analysisData.size();
+  int numChildren = (int)analysisData.size();
 
   //Apply filtering conditions, but include children that don't match the filtering condition
   //but where there are children afterward that do, in case we ever use something more complex

--- a/cpp/tests/testrules.cpp
+++ b/cpp/tests/testrules.cpp
@@ -3414,7 +3414,7 @@ HASH: 5C26A060FA78FD93FFF559C72BD7C6A4
     Board board;
     BoardHistory hist;
     Player nextPla = P_BLACK;
-    int turnIdxToSetup = sgf->moves.size();
+    int turnIdxToSetup = (int)sgf->moves.size();
     Rules initialRules = sgf->getRulesOrFailAllowUnspecified(Rules());
 
     sgf->setupBoardAndHistAssumeLegal(initialRules, board, nextPla, hist, turnIdxToSetup);

--- a/cpp/tests/testtrainingwrite.cpp
+++ b/cpp/tests/testtrainingwrite.cpp
@@ -480,7 +480,7 @@ void Tests::runMoreSelfplayTestsWithNN(const string& modelFile) {
     }
     if(testHint) {
       otherGameProps.isHintPos = true;
-      otherGameProps.hintTurn = initialHist.moveHistory.size();
+      otherGameProps.hintTurn = (int)initialHist.moveHistory.size();
       otherGameProps.hintPosHash = initialBoard.pos_hash;
       otherGameProps.hintLoc = Location::ofString("A1",initialBoard);
       otherGameProps.allowPolicyInit = false;
@@ -1916,7 +1916,7 @@ void Tests::runSekiTrainWriteTests(const string& modelFile) {
     extraBlackAndKomi.extraBlack = 0;
     extraBlackAndKomi.komiMean = rules.komi;
     extraBlackAndKomi.komiStdev = 0;
-    int turnIdx = sgf->moves.size();
+    int turnIdx = (int)sgf->moves.size();
     sgf->setupBoardAndHistAssumeLegal(rules,initialBoard,initialPla,initialHist,turnIdx);
 
     bool doEndGameIfAllPassAlive = true;


### PR DESCRIPTION
Fix up two more spots in KataGo where Windows characters encodings weren't handled - one is that when finding the home data dir, we need to utf8ify the path that Windows gives us back, the other is that when writing to stdout or stderr we need to convert from utf8 back to windows native with a custom stream buffer.

Also a bunch of minor changes to reduce the number of MSVC warnings.