### PR TITLE
Add GTP kata-set-param maxVisits parameter

### DIFF
--- a/cpp/command/gtp.cpp
+++ b/cpp/command/gtp.cpp
@@ -571,6 +571,11 @@ struct GTPEngine {
     bot->setParams(params);
     bot->clearSearch();
   }
+  void setMaxVisits(int maxVisits) {
+    params.maxVisits = maxVisits;
+    bot->setParams(params);
+    bot->clearSearch();
+  }
 
   void updateDynamicPDA() {
     updateDynamicPDAHelper(
@@ -2143,6 +2148,14 @@ int MainCmds::gtp(const vector<string>& args) {
           else {
             responseIsError = true;
             response = "Invalid value for " + pieces[0] + ", must be integer from 1 to 1024";
+          }
+        }
+        else if(pieces[0] == "maxVisits") {
+          if(Global::tryStringToInt(pieces[1],i) && i >= 1 && i <= (int64_t)1 << 50)
+            engine->setMaxVisits(i);
+          else {
+            responseIsError = true;
+            response = "Invalid value for " + pieces[0] + ", must be integer from 1 to 2^50";
           }
         }
         else {


### PR DESCRIPTION
Changing the MaxVisits on a running instance has a multitude of use cases. A few examples are:
- Different strength/calculation time for different stages of the game (e.g. quickly finishing in the endgame).
- AI vs AI games with different strengths per side.

The reason I made this is because I need it myself to not need multiple instances for a single game. (https://discord.com/channels/417022162348802048/583775968804732928/1026510646784839711)

I've build and tested it and it works without issues.