### PR TITLE
Added missing gtp extension commands to documentation.

### DIFF
--- a/cpp/command/gtp.cpp
+++ b/cpp/command/gtp.cpp
@@ -93,6 +93,7 @@ static const vector<string> knownCommands = {
 
   //Some debug commands
   "kata-debug-print-tc",
+  "debug_moves",
 
   //Stop any ongoing ponder or analyze
   "stop",

--- a/docs/GTP_Extensions.md
+++ b/docs/GTP_Extensions.md
@@ -185,3 +185,18 @@ In addition to a basic set of [GTP commands](https://www.lysator.liu.se/~gunnar/
      * Run a benchmark using exactly the current search settings and board size except for any visit or playout or time limits ignored, instead using NVISITS visits.
      * Prints the result, in some user-readable format.
      * Will halt any ongoing search, may have the side effect of clearing the nn cache.
+  * `printsgf [FILENAME]`
+     * Dumps the current position as a static sgf file to FILENAME, or as output if FILENAME missing or "-".
+
+----
+
+Debugging commands can change without warning, and their existence or data formatting should not be relied upon for scripting or automation purposes.
+
+  * `kata-debug-print-tc`
+     * Prints debugging information about time controls for white and black.
+  * `debug_moves ["rawstats"] [MOVE]...`
+     * Prints debugging statistics about move selections.  If "rawstats" is provided the engine will print out extended information about the move.  If a list of MOVE is provided the engine will print out information about that particular variation from the current play position.
+  * `genmove_debug`
+     * Functions exactly the same as `genmove`, but will print out addition debugging information to stderr.
+  * `search_debug`
+     * Functions exactly the same as `genmove_debug`, but will not actually perform a move.

--- a/docs/GTP_Extensions_next.md
+++ b/docs/GTP_Extensions_next.md
@@ -186,3 +186,18 @@ In addition to a basic set of [GTP commands](https://www.lysator.liu.se/~gunnar/
      * Run a benchmark using exactly the current search settings and board size except for any visit or playout or time limits ignored, instead using NVISITS visits.
      * Prints the result, in some user-readable format.
      * Will halt any ongoing search, may have the side effect of clearing the nn cache.
+  * `printsgf [FILENAME]`
+     * Dumps the current position as a static sgf file to FILENAME, or as output if FILENAME missing or "-".
+
+----
+
+Debugging commands can change without warning, and their existence or data formatting should not be relied upon for scripting or automation purposes.
+
+  * `kata-debug-print-tc`
+     * Prints debugging information about time controls for white and black.
+  * `debug_moves ["rawstats"] [MOVE]...`
+     * Prints debugging statistics about move selections.  If "rawstats" is provided the engine will print out extended information about the move.  If a list of MOVE is provided the engine will print out information about that particular variation from the current play position.
+  * `genmove_debug` COLOR
+     * Functions exactly the same as `genmove`, but will print out addition debugging information to stderr.
+  * `search_debug` COLOR
+     * Functions exactly the same as `genmove_debug`, but will not actually perform a move.


### PR DESCRIPTION
It seems that when the `printsgf` command was added, it was not added to the documentation.  This PR is designed to rectify this.  While going through the rest of the exposed sgf commands I came across one other debugging command that isn't documented.  I have also added this; however, I'm not confident that this is necessarily the sort of command that ought to be documented, so let me know if you need me to remove that, (or if I got the description of the command wrong.)