### PR TITLE
remove duplicate error messages for bad board size

### DIFF
--- a/cpp/command/analysis.cpp
+++ b/cpp/command/analysis.cpp
@@ -617,11 +617,9 @@ int MainCmds::analysis(const vector<string>& args) {
           continue;
         }
         if(!parseInteger(input, "boardXSize", xBuf, 2, Board::MAX_LEN, boardSizeError.c_str())) {
-          reportErrorForId(rbase.id, "boardXSize", boardSizeError.c_str());
           continue;
         }
         if(!parseInteger(input, "boardYSize", yBuf, 2, Board::MAX_LEN, boardSizeError.c_str())) {
-          reportErrorForId(rbase.id, "boardYSize", boardSizeError.c_str());
           continue;
         }
         boardXSize = (int)xBuf;


### PR DESCRIPTION
`parseInteger()` in `analysis.cpp` generates an `{error}` object (for the GUI) when it fails; it also returns false, but when the main loop sees the false return value, it also generates an error, leading to 2 `{error}` objects being sent to the GUI.

This PR removes the duplication.

Note: not actually tested. I've no C++ compiler.