### PR TITLE
Mitigation for assertion crashes associated with NaN policy sum errors

### DIFF
--- a/cpp/command/analysis.cpp
+++ b/cpp/command/analysis.cpp
@@ -267,6 +267,11 @@ int MainCmds::analysis(const vector<string>& args) {
 
     if(success)
       pushToWrite(new string(ret.dump()));
+    else {
+      ret["error"] = "No search results or root node";
+      pushToWrite(new string(ret.dump()));
+    }
+
     return success;
   };
 

--- a/cpp/search/searchexplorehelpers.cpp
+++ b/cpp/search/searchexplorehelpers.cpp
@@ -252,7 +252,7 @@ double Search::getFpuValueForChildrenAssumeVisited(
   double utilitySqAvg = node.stats.utilitySqAvg.load(std::memory_order_acquire);
 
   assert(visits > 0);
-  assert(weightSum > 0.0);
+  //assert(weightSum > 0.0);
   parentWeightPerVisit = weightSum / visits;
   parentUtility = utilityAvg;
   double variancePrior = searchParams.cpuctUtilityStdevPrior * searchParams.cpuctUtilityStdevPrior;


### PR DESCRIPTION
This is an attempt to work around the issue described in #694  in which we get "nonfinite for policy sum" errors for games that are hopelessly unbalanced when running with the TensorRT backend. 

In that issue it sounds like the belief is that the root cause of this issue lies as a bug is on the nvidia side of things, so this patch is an attempt to not abort when we run into those situations while we wait for nvidia to resolve the issue.




