### PR TITLE
Fix segmentation fault when using the match option "extraPairs"

### DIFF
--- a/cpp/command/match.cpp
+++ b/cpp/command/match.cpp
@@ -80,6 +80,37 @@ int MainCmds::match(const vector<string>& args) {
     }
   }
 
+  vector<bool> extraPairsBot(numBots);
+  // But flag if the bot is not to be part of normal matchmaking, but needs to
+  // be loaded anyway.
+  if (cfg.contains("extraPairs")) {
+    string pairsStr = cfg.getString("extraPairs");
+    std::vector<string> pairStrs = Global::split(pairsStr,',');
+    for(const string& pairStr: pairStrs) {
+      if(Global::trim(pairStr).size() <= 0)
+        continue;
+      std::vector<string> pieces = Global::split(Global::trim(pairStr),'-');
+      if(pieces.size() != 2) {
+        throw IOError("Could not parse pair: " + pairStr);
+      }
+      bool suc;
+      int p0;
+      int p1;
+      suc = Global::tryStringToInt(pieces[0],p0);
+      if(!suc)
+        throw IOError("Could not parse pair: " + pairStr);
+      suc = Global::tryStringToInt(pieces[1],p1);
+      if(!suc)
+        throw IOError("Could not parse pair: " + pairStr);
+      if(p0 < 0 || p0 >= numBots)
+        throw IOError("Invalid player index in pair: " + pairStr);
+      if(p1 < 0 || p1 >= numBots)
+        throw IOError("Invalid player index in pair: " + pairStr);
+      extraPairsBot[p0] = true;
+      extraPairsBot[p1] = true;
+    }
+  }
+
   //Load the names of the bots and which model each bot is using
   vector<string> nnModelFilesByBot(numBots);
   vector<string> botNames(numBots);
@@ -103,7 +134,7 @@ int MainCmds::match(const vector<string>& args) {
   vector<string> nnModelFiles;
   vector<int> whichNNModel(numBots);
   for(int i = 0; i<numBots; i++) {
-    if(excludeBot[i])
+    if(excludeBot[i] && !extraPairsBot[i])
       continue;
 
     const string& desiredFile = nnModelFilesByBot[i];
@@ -165,7 +196,7 @@ int MainCmds::match(const vector<string>& args) {
 
   vector<NNEvaluator*> nnEvalsByBot(numBots);
   for(int i = 0; i<numBots; i++) {
-    if(excludeBot[i])
+    if(excludeBot[i] && !extraPairsBot[i])
       continue;
     nnEvalsByBot[i] = nnEvals[whichNNModel[i]];
   }


### PR DESCRIPTION
The option "extraPairs" does not initialize the bots found in the pairs, because they are excluded by the "includeBots" command.  This duplicates some parsing logic, which might be better consolidated elsewhere, but rather than making that call, I just copy pasted the code.