### PR TITLE
update to avoid trt API Usage Error

### DIFF
--- a/cpp/neuralnet/trtbackend.cpp
+++ b/cpp/neuralnet/trtbackend.cpp
@@ -923,6 +923,7 @@ struct ComputeHandle {
   TRTLogger trtLogger;
   map<string, void*> buffers;
   unique_ptr<ICudaEngine> engine;
+  unique_ptr<IRuntime> runtime;
   unique_ptr<IExecutionContext> exec;
 
   ComputeHandle(
@@ -1171,7 +1172,7 @@ struct ComputeHandle {
 #endif
     }
 
-    auto runtime = unique_ptr<IRuntime>(createInferRuntime(trtLogger));
+    runtime.reset(createInferRuntime(trtLogger));
     if(!runtime) {
       throw StringError("TensorRT backend: failed to create runtime");
     }
@@ -1203,6 +1204,10 @@ struct ComputeHandle {
     for(auto ptr: buffers) {
       CUDA_ERR("~ComputeHandle", cudaFree(ptr.second));
     }
+
+    exec.reset();
+    engine.reset();
+    runtime.reset();
   }
 
   ComputeHandle() = delete;


### PR DESCRIPTION
for trt version 8.6, there will be an error like: TensorRT backend: 3: [runtime.cpp::~Runtime::346] Error Code 3: API Usage Error (Parameter check failed at: runtime/rt/runtime.cpp::~Runtime::346, condition: mEngineCounter.use_count() == 1. Destroying a runtime before destroying deserialized engines created by the runtime leads to undefined behavior.

this pr helps fix it