### PR TITLE
add plan cache to cmake opts

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -31,6 +31,7 @@ string(TOUPPER "${USE_BACKEND}" USE_BACKEND)
 set_property(CACHE USE_BACKEND PROPERTY STRINGS "" CUDA TENSORRT OPENCL EIGEN)
 
 set(USE_TCMALLOC 0 CACHE BOOL "Use TCMalloc")
+set(USE_CACHE_TENSORRT_PLAN 0 CACHE BOOL "Use TENSORRT plan cache")
 set(NO_GIT_REVISION 0 CACHE BOOL "Disable embedding the git revision into the compiled exe")
 set(USE_AVX2 0 CACHE BOOL "Compile with AVX2")
 set(USE_BIGGER_BOARDS_EXPENSIVE 0 CACHE BOOL "Allow boards up to size 29. Compiling with this will use more memory and slow down KataGo, even when playing on boards of size 19.")
@@ -98,6 +99,12 @@ elseif(USE_BACKEND STREQUAL "")
   set(NEURALNET_BACKEND_SOURCES neuralnet/dummybackend.cpp)
 else()
   message(FATAL_ERROR "Unrecognized backend: " ${USE_BACKEND})
+endif()
+
+
+if(USE_CACHE_TENSORRT_PLAN)
+    message(STATUS "-DUSE_CACHE_TENSORRT_PLAN is set, using TENSORRT plan cache.")
+    add_compile_definitions(CACHE_TENSORRT_PLAN)
 endif()
 
 


### PR DESCRIPTION
so that in cmake, we can use:
-DUSE_CACHE_TENSORRT_PLAN=1
or
-DUSE_CACHE_TENSORRT_PLAN=0
to turn on/off the trt plan cache