### PR TITLE
Fix Warnings for Copying in Range-based For Loops

### DIFF
--- a/cpp/command/match.cpp
+++ b/cpp/command/match.cpp
@@ -143,7 +143,7 @@ int MainCmds::match(const vector<string>& args) {
   }
 
   vector<bool> botIsUsed(numBots);
-  for(const std::pair<int,int> pair: matchupsPerRound) {
+  for(const std::pair<int,int>& pair : matchupsPerRound) {
     botIsUsed[pair.first] = true;
     botIsUsed[pair.second] = true;
   }

--- a/cpp/program/play.cpp
+++ b/cpp/program/play.cpp
@@ -363,7 +363,7 @@ void GameInitializer::initShared(ConfigParser& cfg, Logger& logger) {
   minBoardYSize = allowedBSizes[0].second;
   maxBoardXSize = allowedBSizes[0].first;
   maxBoardYSize = allowedBSizes[0].second;
-  for(const std::pair<int,int> bSize: allowedBSizes) {
+  for(const std::pair<int,int>& bSize : allowedBSizes) {
     minBoardXSize = std::min(minBoardXSize, bSize.first);
     minBoardYSize = std::min(minBoardYSize, bSize.second);
     maxBoardXSize = std::max(maxBoardXSize, bSize.first);


### PR DESCRIPTION
This Pull Request addresses two warnings generated during the build process of KataGo regarding the copying of objects in range-based for loops. The warnings are related to unnecessary copying of std::pair<int, int> objects in play.cpp and match.cpp.

**Warnings Addressed:**
```
/root/KataGo/cpp/program/play.cpp: In member function 'void GameInitializer::initShared(ConfigParser&, Logger&)':
/root/KataGo/cpp/program/play.cpp:366:32: warning: loop variable 'bSize' creates a copy from type 'const std::pair<int, int>' [-Wrange-loop-construct]
  366 |   for(const std::pair<int,int> bSize: allowedBSizes) {
      |                                ^~~~~
/root/KataGo/cpp/program/play.cpp:366:32: note: use reference type to prevent copying
  366 |   for(const std::pair<int,int> bSize: allowedBSizes) {
      |                                ^~~~~
      |                                &
	  
	  
	  
/root/KataGo/cpp/command/match.cpp: In function 'int MainCmds::match(const std::vector<std::__cxx11::basic_string<char> >&)':
/root/KataGo/cpp/command/match.cpp:146:32: warning: loop variable 'pair' creates a copy from type 'const std::pair<int, int>' [-Wrange-loop-construct]
  146 |   for(const std::pair<int,int> pair: matchupsPerRound) {
      |                                ^~~~
/root/KataGo/cpp/command/match.cpp:146:32: note: use reference type to prevent copying
  146 |   for(const std::pair<int,int> pair: matchupsPerRound) {
      |                                ^~~~
      |                                &
```

**Solution:**
Both warnings are resolved by changing the loop variable to a reference type. This change prevents unnecessary copying and thereby optimizes the performance. The loops now iterate over references rather than creating copies of the pairs.

This modification ensures more efficient code execution with no change to the existing logic or functionality. It's a small contribution but I hope it can help a little for this project.