### PR TITLE
HSL GUI keybinds and board rotation fix

### DIFF
--- a/python/humanslnet_gui.py
+++ b/python/humanslnet_gui.py
@@ -57,12 +57,12 @@ def load_sgf_game_state(file_path):
         for y in range(size):
             color = board.get(x, y)
             if color is not None:
-                moves.append((x, y, (Board.BLACK if color == "b" else Board.WHITE)))
+                moves.append((y, 18 - x, (Board.BLACK if color == "b" else Board.WHITE)))
 
     for color, move in plays:
         if move is not None:
             x, y = move
-            moves.append((x, y, (Board.BLACK if color == "b" else Board.WHITE)))
+            moves.append((y, 18 - x, (Board.BLACK if color == "b" else Board.WHITE)))
 
     game_state = GameState(size, GameState.RULES_JAPANESE)
     for (x,y,color) in moves:


### PR DESCRIPTION
Added the following keybinds:
- Left arrow + Shift: Go 10 moves back
- Right arrow + Shift: Go 10 moves forward
- Up arrow: Go to the end of the game
- Down arrow: Go to the start of the game

When loading an sgf, the board was always rotates 90 degrees to the right.
GameState uses a coordinate pivot point at the top left while Sgfmill seems to use a different system. I fixed this by swapping x and y and inverting x when the sgf data is exported from Sgfmill into a GameState.