### PR TITLE
added web server support for human sl

### DIFF
--- a/python/flask_wrapper_human_sl_server.py
+++ b/python/flask_wrapper_human_sl_server.py
@@ -1,0 +1,87 @@
+from flask import Flask, request, jsonify
+from subprocess import Popen, PIPE, STDOUT
+import threading
+import json
+import os
+from flask_cors import CORS, cross_origin
+app = Flask(__name__)
+cors = CORS(app)
+app.config['CORS_HEADERS'] = 'Content-Type'
+
+app = Flask(__name__)
+
+# Store the process globally
+cli_process = None
+lock = threading.Lock()
+
+def start_cli():
+    global cli_process
+    command = "python ./humanslnet_server.py -checkpoint ./b18c384nbt-humanv0.ckpt -device cpu -webserver"
+
+    with lock:
+        if cli_process is None:
+            cli_process = Popen(command, shell=True, stdin=PIPE, stdout=PIPE, stderr=STDOUT, text=True)
+            wait_for_ready_state(cli_process)
+
+def wait_for_ready_state(process):
+    """Reads lines from the CLI program until it outputs the ready state message."""
+    try:
+        while True:
+            line = process.stdout.readline()
+            if not line:
+                break
+            print(f"Initial CLI Output: {line.strip()}")  # Print the initial output for debugging
+            
+            if "Ready to receive input" in line:
+                print("CLI program is ready.")
+                break  # Stop reading once the ready state is detected
+    except Exception as e:
+        print(f"Error reading initial output: {str(e)}")
+
+@app.route('/', methods=['POST'])
+@cross_origin()
+def run_cli():
+    global cli_process
+    input_data = request.json
+
+    if not input_data:
+        return jsonify({'error': 'No input provided'}), 400
+
+    with lock:
+        if cli_process is None:
+            start_cli()
+            return jsonify({'error': 'CLI program was not running, restarted'}), 400
+
+        try:
+            # Send input to the process
+            input_json = json.dumps(input_data)
+            cli_process.stdin.write(input_json + '\n')
+            cli_process.stdin.flush()
+
+            # Read the output from the process until all responses are received
+            num_responses_expected = 1
+            responses = []
+            while len(responses) < num_responses_expected:
+                output_line = cli_process.stdout.readline()
+                if not output_line:
+                    break
+                output_line = output_line.strip()
+                
+                try:
+                    # Attempt to parse the output as JSON
+                    response_data = json.loads(output_line)
+                    responses.append(response_data)
+                except json.JSONDecodeError:
+                    # Ignore lines that are not valid JSON
+                    print(f"Non-JSON line ignored: {output_line}")
+
+            if len(responses) != num_responses_expected:
+                return jsonify({'error': 'Did not receive the expected number of responses from CLI program'}), 500
+
+            return jsonify(responses)
+        except Exception as e:
+            return jsonify({'error': f'An error occurred: {str(e)}'}), 500
+
+if __name__ == '__main__':
+    start_cli()  # Start the CLI program when the server starts
+    app.run(host='0.0.0.0', port=5000)

--- a/python/humanslnet_server.py
+++ b/python/humanslnet_server.py
@@ -14,11 +14,16 @@ def numpy_array_encoder(obj):
         return float(obj)
     raise TypeError(f'Object of type {obj.__class__.__name__} is not JSON serializable')
 
+def write(output):
+        sys.stdout.write(json.dumps(output,default=numpy_array_encoder) + "\n")
+        sys.stdout.flush()
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('-checkpoint', help='Checkpoint to test', required=True)
     parser.add_argument('-use-swa', help='Use SWA model', action="store_true", required=False)
     parser.add_argument('-device', help='Device to use, such as cpu or cuda:0', required=True)
+    parser.add_argument('-webserver', help='set if is used for the flask wrapper', required=False)
     args = parser.parse_args()
 
     model, swa_model, _ = load_model(args.checkpoint, use_swa=args.use_swa, device=args.device, pos_len=19, verbose=False)
@@ -26,10 +31,10 @@ def main():
         model = swa_model
     game_state = None
 
-    def write(output):
-        sys.stdout.write(json.dumps(output,default=numpy_array_encoder) + "\n")
-        sys.stdout.flush()
+    if args.webserver:
+        write("Ready to receive input")
 
+    
     # DEBUGGING
     # game_state = GameState(board_size=19, rules=GameState.RULES_JAPANESE)
     # sgfmeta = SGFMetadata()

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,5 @@
+matplotlib==3.9.0
+numpy==2.0.1
+torch==2.4.0
+wxPython==4.2.1
+flask_cors==4.0.1


### PR DESCRIPTION
This adds a flask wrapper `flask_wrapper_human_sl_server.py` around the `humanslnet_server.py`
It's useful for integration with front ends, to allow them to do web requests to the `humanslnet_server.py`
`humanslnet_server.py` gives a higher degree of control over the settings of the simulation, which can be preferable over the courser settings found in `katago analysis`

This is a working front end for it that I've implemented in ionic, cross platform React.js
I'm aiming to compile this to android and ios.
Android has support for pytorch using , so hopefully that will be doable. https://github.com/chaquo/chaquopy/issues/477
![Screenshot at 2024-08-07 21-48-02](https://github.com/user-attachments/assets/69366490-da2e-490b-8043-858648ac1f11)
