### PR TITLE
fix b1c6nbt model invalid mid_num_channels setting.

### DIFF
--- a/python/modelconfigs.py
+++ b/python/modelconfigs.py
@@ -77,7 +77,7 @@ b1c6nbt = {
     "bnorm_running_avg_momentum": 0.001,
     "initial_conv_1x1": False,
     "trunk_num_channels":6,
-    "mid_num_channels":4,
+    "mid_num_channels":6,
     "gpool_num_channels":4,
     "use_attention_pool":False,
     "num_attention_pool_heads":2,


### PR DESCRIPTION
### Issue

When running b1c6nbt with c++ engine, it will trigger this error.
`
terminate called after throwing an instance of 'StringError'
  what():  Error loading or parsing model file /b1c6nbt-s31704192-d83750556/model.bin.gz: trunk: all numbers of channels must be positive
`


### trunk exported here
def write_trunk(name,model):
    writeln("trunk")
    writeln(len(model.blocks))
    writeln(model.c_trunk)
    writeln(model.c_mid)
    writeln(model.c_mid-model.c_gpool)
    writeln(model.c_gpool)
    writeln(model.c_gpool)

### Error thrown here
TrunkDesc::TrunkDesc(istream& in, int vrsn, bool binaryFloats) {
  in >> name;
  version = vrsn;
  in >> numBlocks;
  in >> trunkNumChannels;
  in >> midNumChannels;
  in >> regularNumChannels;
  int dilatedNumChannels; //unused
  in >> dilatedNumChannels;
  in >> gpoolNumChannels;

  if(in.fail())
    throw StringError(name + ": trunk failed to parse num blocks or various channel parameters");
  if(numBlocks < 1)
    throw StringError(name + ": trunk num blocks must be positive");
  if(
    trunkNumChannels <= 0 || midNumChannels <= 0 || regularNumChannels <= 0 ||
    gpoolNumChannels <= 0)
    throw StringError(name + ": all numbers of channels must be positive");


