### PR TITLE
Fix to arguments to GameState() in play.py

### DIFF
--- a/python/play.py
+++ b/python/play.py
@@ -443,9 +443,9 @@ while True:
             print("Warning: Trying to set incompatible boardsize %s (!= %d)" % (command[1], N), file=sys.stderr)
             ret = None
         board_size = int(command[1])
-        gs = GameState(board_size)
+        gs = GameState(board_size, GameState.RULES_TT)
     elif command[0] == "clear_board":
-        gs = GameState(board_size)
+        gs = GameState(board_size, GameState.RULES_TT)
     elif command[0] == "showboard":
         ret = "\n" + gs.board.to_string().strip()
     elif command[0] == "komi":


### PR DESCRIPTION
I noticed a minor bug in play.py. At some point the arguments to the constructor for GameState were changed to take ruleset as well as board size, but a couple of places it's used in play.py are still calling it with only board size. I just added Tromp-Taylor rules as argument, since that's what's done earlier on in the file.