### PR TITLE
Eval cache rebased

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -227,6 +227,7 @@ add_executable(katago
   search/localpattern.cpp
   search/searchnodetable.cpp
   search/subtreevaluebiastable.cpp
+  search/evalcache.cpp
   search/patternbonustable.cpp
   search/analysisdata.cpp
   search/reportedsearchvalues.cpp

--- a/cpp/dataio/sgf.cpp
+++ b/cpp/dataio/sgf.cpp
@@ -1111,6 +1111,23 @@ Sgf::PositionSample Sgf::PositionSample::previousPosition(double newWeight) cons
   return other;
 }
 
+BoardHistory Sgf::PositionSample::getCurrentBoardHistory(const Rules& rules, Player& nextPlaToMove) const {
+  int encorePhase = 0;
+  Player pla = nextPla;
+  Board boardCopy = board;
+  BoardHistory hist(boardCopy,pla,rules,encorePhase);
+  int numSampleMoves = (int)moves.size();
+  for(int i = 0; i<numSampleMoves; i++) {
+    if(!hist.isLegal(boardCopy,moves[i].loc,moves[i].pla))
+      return hist;
+    assert(moves[i].pla == pla);
+    hist.makeBoardMoveAssumeLegal(boardCopy,moves[i].loc,moves[i].pla,NULL);
+    pla = getOpp(pla);
+  }
+  nextPlaToMove = pla;
+  return hist;
+}
+
 int64_t Sgf::PositionSample::getCurrentTurnNumber() const {
   return std::max((int64_t)0, initialTurnNumber + (int64_t)moves.size());
 }

--- a/cpp/dataio/sgf.h
+++ b/cpp/dataio/sgf.h
@@ -123,6 +123,8 @@ struct Sgf {
     Sgf::PositionSample previousPosition(double newWeight) const;
     bool hasPreviousPositions(int numPrevious) const;
 
+    BoardHistory getCurrentBoardHistory(const Rules& rules, Player& nextPlaToMove) const;
+
     int64_t getCurrentTurnNumber() const;
 
     //For the moment, only used in testing since it does extra consistency checks.

--- a/cpp/game/boardhistory.cpp
+++ b/cpp/game/boardhistory.cpp
@@ -1239,6 +1239,8 @@ Hash128 BoardHistory::getSituationRulesAndKoHash(const Board& board, const Board
     hash ^= Rules::ZOBRIST_MULTI_STONE_SUICIDE_HASH;
   if(hist.hasButton)
     hash ^= Rules::ZOBRIST_BUTTON_HASH;
+  if(hist.rules.friendlyPassOk)
+    hash ^= Rules::ZOBRIST_FRIENDLY_PASS_OK_HASH;
 
   return hash;
 }

--- a/cpp/game/rules.cpp
+++ b/cpp/game/rules.cpp
@@ -614,3 +614,7 @@ const Hash128 Rules::ZOBRIST_MULTI_STONE_SUICIDE_HASH =   //Based on sha256 hash
 
 const Hash128 Rules::ZOBRIST_BUTTON_HASH =   //Based on sha256 hash of Rules::ZOBRIST_BUTTON_HASH
   Hash128(0xb8b914c9234ece84ULL, 0x3d759cddebe29c14ULL);
+
+const Hash128 Rules::ZOBRIST_FRIENDLY_PASS_OK_HASH =   //Based on sha256 hash of Rules::ZOBRIST_FRIENDLY_PASS_OK_HASH
+  Hash128(0x0113655998ef0a25ULL, 0x99c9d04ecd964874ULL);
+

--- a/cpp/game/rules.h
+++ b/cpp/game/rules.h
@@ -101,6 +101,7 @@ struct Rules {
   static const Hash128 ZOBRIST_TAX_RULE_HASH[3];
   static const Hash128 ZOBRIST_MULTI_STONE_SUICIDE_HASH;
   static const Hash128 ZOBRIST_BUTTON_HASH;
+  static const Hash128 ZOBRIST_FRIENDLY_PASS_OK_HASH;
 
 private:
   nlohmann::json toJsonHelper(bool omitKomi, bool omitDefaults) const;

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -142,6 +142,8 @@ static int handleSubcommand(const string& subcommand, const vector<string>& args
     return MainCmds::trystartposes(subArgs);
   else if(subcommand == "viewstartposes")
     return MainCmds::viewstartposes(subArgs);
+  else if(subcommand == "checksgfhintpolicy")
+    return MainCmds::checksgfhintpolicy(subArgs);
   else if(subcommand == "demoplay")
     return MainCmds::demoplay(subArgs);
   else if(subcommand == "writetrainingdata")

--- a/cpp/main.h
+++ b/cpp/main.h
@@ -46,6 +46,7 @@ namespace MainCmds {
 
   int trystartposes(const std::vector<std::string>& args);
   int viewstartposes(const std::vector<std::string>& args);
+  int checksgfhintpolicy(const std::vector<std::string>& args);
 
   int demoplay(const std::vector<std::string>& args);
   int printclockinfo(const std::vector<std::string>& args);

--- a/cpp/program/setup.cpp
+++ b/cpp/program/setup.cpp
@@ -702,6 +702,14 @@ vector<SearchParams> Setup::loadParams(
     else if(cfg.contains("subtreeValueBiasWeightExponent")) params.subtreeValueBiasWeightExponent = cfg.getDouble("subtreeValueBiasWeightExponent", 0.0, 1.0);
     else params.subtreeValueBiasWeightExponent = 0.85;
 
+    if(cfg.contains("useEvalCache"+idxStr)) params.useEvalCache = cfg.getBool("useEvalCache"+idxStr);
+    else if(cfg.contains("useEvalCache"))   params.useEvalCache = cfg.getBool("useEvalCache");
+    else                                    params.useEvalCache = false;
+
+    if(cfg.contains("evalCacheMinVisits"+idxStr)) params.evalCacheMinVisits = cfg.getInt64("evalCacheMinVisits"+idxStr, (int64_t)1, (int64_t)1 << 50);
+    else if(cfg.contains("evalCacheMinVisits"))   params.evalCacheMinVisits = cfg.getInt64("evalCacheMinVisits",        (int64_t)1, (int64_t)1 << 50);
+    else                                          params.evalCacheMinVisits = 100;
+
     if(cfg.contains("nodeTableShardsPowerOfTwo"+idxStr)) params.nodeTableShardsPowerOfTwo = cfg.getInt("nodeTableShardsPowerOfTwo"+idxStr, 8, 24);
     else if(cfg.contains("nodeTableShardsPowerOfTwo"))   params.nodeTableShardsPowerOfTwo = cfg.getInt("nodeTableShardsPowerOfTwo",        8, 24);
     else                                                 params.nodeTableShardsPowerOfTwo = 16;

--- a/cpp/search/evalcache.cpp
+++ b/cpp/search/evalcache.cpp
@@ -1,0 +1,121 @@
+#include "../search/evalcache.h"
+
+#include "../search/searchnode.h"
+
+//------------------------
+#include "../core/using.h"
+//------------------------
+
+FirstExploreEval::FirstExploreEval()
+  :avgWinLoss(0.0f),
+   avgScoreMean(0.0f),
+   cacheWeight(0.0f)
+{}
+FirstExploreEval::FirstExploreEval(float avgWL, float avgSM, float w)
+  :avgWinLoss(avgWL),
+   avgScoreMean(avgSM),
+   cacheWeight(w)
+{}
+
+
+EvalCacheEntry::EvalCacheEntry()
+  :avgWinLoss(0.0f),
+   avgNoResult(0.0f),
+   avgScoreMean(0.0f),
+   avgLead(0.0f),
+   cacheWeight(0.0f),
+   firstExploreEvals()
+{}
+
+EvalCacheTable::EvalCacheTable(int32_t numShards) {
+  mutexPool = new MutexPool(numShards);
+  entries.resize(numShards);
+}
+EvalCacheTable::~EvalCacheTable() {
+  for(const std::map<Hash128,EvalCacheEntry*>& map: entries) {
+    for(const auto& pair: map) {
+      delete pair.second;
+    }
+  }
+  delete mutexPool;
+}
+
+EvalCacheEntry* EvalCacheTable::find(Hash128 graphHash) {
+  uint32_t subMapIdx = (uint32_t)(graphHash.hash0 % entries.size());
+  auto iter = entries[subMapIdx].find(graphHash);
+  if(iter == entries[subMapIdx].end())
+    return NULL;
+  return iter->second;
+}
+
+void EvalCacheTable::update(Hash128 graphHash, const SearchNode* node, int64_t evalCacheMinVisits, bool isRootNode) {
+  uint32_t subMapIdx = (uint32_t)(graphHash.hash0 % entries.size());
+  std::mutex& mutex = mutexPool->getMutex(subMapIdx);
+  std::lock_guard<std::mutex> lock(mutex);
+
+  EvalCacheEntry*& entry = entries[subMapIdx][graphHash];
+  if(entry == NULL)
+    entry = new EvalCacheEntry();
+
+  ConstSearchNodeChildrenReference children = node->getChildren();
+  int childrenCapacity = children.getCapacity();
+  for(int i = 0; i<childrenCapacity; i++) {
+    const SearchNode* child = children[i].getIfAllocated();
+    if(child == NULL)
+      break;
+
+    int64_t childNumVisits = child->stats.visits.load(std::memory_order_acquire);
+    float childWinLossAvg = (float)(child->stats.winLossValueAvg.load(std::memory_order_acquire));
+    float childScoreMeanAvg = (float)(child->stats.scoreMeanAvg.load(std::memory_order_acquire));
+    Loc moveLoc = children[i].getMoveLocRelaxed();
+    if(childNumVisits >= evalCacheMinVisits) {
+      float childCacheWeight = (float)childNumVisits;
+      FirstExploreEval& eval = entry->firstExploreEvals[moveLoc];
+      if(childCacheWeight >= eval.cacheWeight) {
+        eval = FirstExploreEval(childWinLossAvg,childScoreMeanAvg,childCacheWeight);
+      }
+    }
+  }
+
+  float newCacheWeight = (float)(node->stats.visits.load(std::memory_order_acquire));
+  if(newCacheWeight < entry->cacheWeight * 0.75f)
+    return;
+
+  //Should we record this node's aggregate evals in the cache?
+  //Or should we only leave it at recording initial first-play evals for exploring children?
+  bool shouldRecordEvals = true;
+  if(isRootNode) {
+    //On the root node, due to it handling passing differently than other nodes, we do NOT record it if passing
+    //is near the highest utility move or is at least a third of the visits.
+    int64_t totalEdgeVisits = 0;
+    int64_t passEdgeVisits = 0;
+    double maxSelfUtility = -1e50;
+    double passSelfUtility = -1e50;
+    for(int i = 0; i<childrenCapacity; i++) {
+      const SearchChildPointer& childPointer = children[i];
+      const SearchNode* child = childPointer.getIfAllocated();
+      if(child == NULL)
+        break;
+      int64_t edgeVisits = childPointer.getEdgeVisits();
+      double childUtility = child->stats.utilityAvg.load(std::memory_order_acquire);
+      double selfUtility = node->nextPla == P_WHITE ? childUtility : -childUtility;
+      totalEdgeVisits += edgeVisits;
+      maxSelfUtility = std::max(maxSelfUtility,selfUtility);
+      if(childPointer.getMoveLocRelaxed() == Board::PASS_LOC) {
+        passEdgeVisits += edgeVisits;
+        passSelfUtility = selfUtility;
+      }
+    }
+    if(passEdgeVisits * 3 >= totalEdgeVisits || passSelfUtility + 0.01 >= maxSelfUtility) {
+      shouldRecordEvals = false;
+    }
+  }
+
+  if(shouldRecordEvals) {
+    entry->cacheWeight = newCacheWeight;
+    entry->avgWinLoss = (float)(node->stats.winLossValueAvg.load(std::memory_order_acquire));
+    entry->avgNoResult = (float)(node->stats.noResultValueAvg.load(std::memory_order_acquire));
+    entry->avgScoreMean = (float)(node->stats.scoreMeanAvg.load(std::memory_order_acquire));
+    entry->avgLead = (float)(node->stats.leadAvg.load(std::memory_order_acquire));
+  }
+}

--- a/cpp/search/evalcache.h
+++ b/cpp/search/evalcache.h
@@ -1,0 +1,43 @@
+#ifndef SEARCH_EVALCACHE_H_
+#define SEARCH_EVALCACHE_H_
+
+#include "../core/global.h"
+#include "../core/hash.h"
+#include "../game/board.h"
+#include "../search/mutexpool.h"
+
+struct FirstExploreEval {
+  float avgWinLoss;
+  float avgScoreMean;
+  float cacheWeight;
+  FirstExploreEval();
+  FirstExploreEval(float avgWinLoss, float avgScoreMean, float cacheWeight);
+};
+
+struct SearchNode;
+
+struct EvalCacheEntry {
+  float avgWinLoss;
+  float avgNoResult;
+  float avgScoreMean;
+  float avgLead;
+  float cacheWeight;
+  std::map<Loc,FirstExploreEval> firstExploreEvals;
+
+  EvalCacheEntry();
+};
+
+struct EvalCacheTable {
+  std::vector<std::map<Hash128,EvalCacheEntry*>> entries;
+  MutexPool* mutexPool;
+
+  EvalCacheTable(int32_t numShards);
+  ~EvalCacheTable();
+
+  EvalCacheEntry* find(Hash128 graphHash);
+  void update(Hash128 graphHash, const SearchNode* node, int64_t evalCacheMinVisits, bool isRootNode);
+};
+
+
+
+#endif // SEARCH_EVALCACHE_H_

--- a/cpp/search/search.cpp
+++ b/cpp/search/search.cpp
@@ -63,6 +63,9 @@ SearchThread::~SearchThread() {
 
 //-----------------------------------------------------------------------------------------
 
+//Based on sha256 of "search.cpp FORCE_NON_TERMINAL_HASH"
+static const Hash128 FORCE_NON_TERMINAL_HASH = Hash128(0xd4c31800cb8809e2ULL,0xf75f9d2083f2ffcaULL);
+
 static const double VALUE_WEIGHT_DEGREES_OF_FREEDOM = 3.0;
 
 Search::Search(SearchParams params, NNEvaluator* nnEval, Logger* lg, const string& rSeed)
@@ -342,6 +345,25 @@ bool Search::makeMove(Loc moveLoc, Player movePla, bool preventEncore) {
   rootPla = getOpp(rootPla);
   rootKoHashTable->recompute(rootHistory);
 
+  //Explicitly clear avoid move arrays when we play a move - user needs to respecify them if they want them.
+  avoidMoveUntilByLocBlack.clear();
+  avoidMoveUntilByLocWhite.clear();
+
+  //If we're newly inferring some moves as handicap that we weren't before, clear since score will be wrong.
+  if(rootHistory.whiteHandicapBonusScore != oldWhiteHandicapBonusScore)
+    clearSearch();
+
+  //In the case that we are conservativePass and a pass would end the game, need to clear the search.
+  //This is because deeper in the tree, such a node would have been explored as ending the game, but now that
+  //it's a root pass, it needs to be treated as if it no longer ends the game.
+  if(searchParams.conservativePass && rootHistory.passWouldEndGame(rootBoard,rootPla))
+    clearSearch();
+
+  //In the case that we're preventing encore, and the phase would have ended, we also need to clear the search
+  //since the search was conducted on the assumption that we're going into encore now.
+  if(preventEncore && rootHistory.passWouldEndPhase(rootBoard,rootPla))
+    clearSearch();
+
   if(rootNode != NULL) {
     SearchNode* child = NULL;
     {
@@ -396,25 +418,6 @@ bool Search::makeMove(Loc moveLoc, Player movePla, bool preventEncore) {
       clearSearch();
     }
   }
-
-  //Explicitly clear avoid move arrays when we play a move - user needs to respecify them if they want them.
-  avoidMoveUntilByLocBlack.clear();
-  avoidMoveUntilByLocWhite.clear();
-
-  //If we're newly inferring some moves as handicap that we weren't before, clear since score will be wrong.
-  if(rootHistory.whiteHandicapBonusScore != oldWhiteHandicapBonusScore)
-    clearSearch();
-
-  //In the case that we are conservativePass and a pass would end the game, need to clear the search.
-  //This is because deeper in the tree, such a node would have been explored as ending the game, but now that
-  //it's a root pass, it needs to be treated as if it no longer ends the game.
-  if(searchParams.conservativePass && rootHistory.passWouldEndGame(rootBoard,rootPla))
-    clearSearch();
-
-  //In the case that we're preventing encore, and the phase would have ended, we also need to clear the search
-  //since the search was conducted on the assumption that we're going into encore now.
-  if(preventEncore && rootHistory.passWouldEndPhase(rootBoard,rootPla))
-    clearSearch();
 
   return true;
 }
@@ -700,15 +703,25 @@ void Search::beginSearch(bool pondering) {
     rootSymmetries.push_back(0);
   }
 
+  //If we're using graph search, we recompute the graph hash from scratch at the start of search.
+  if(searchParams.useGraphSearch)
+    rootGraphHash = GraphHash::getGraphHashFromScratch(rootHistory, rootPla, searchParams.graphSearchRepBound, searchParams.drawEquivalentWinsForWhite);
+  else
+    rootGraphHash = Hash128();
+
   SearchThread dummyThread(-1, *this);
 
   if(rootNode == NULL) {
     //Avoid storing the root node in the nodeTable, guarantee that it never is part of a cycle, allocate it directly.
     //Also force that it is non-terminal.
     const bool forceNonTerminal = rootHistory.isGameFinished; // Make sure the root isn't considered terminal if game would be finished.
-    rootNode = new SearchNode(rootPla, forceNonTerminal, createMutexIdxForNode(dummyThread));
+    Hash128 graphHashMaybeForceNonTerminal = forceNonTerminal ? (rootGraphHash ^ FORCE_NON_TERMINAL_HASH) : rootGraphHash;
+    rootNode = new SearchNode(rootPla, forceNonTerminal, createMutexIdxForNode(dummyThread), graphHashMaybeForceNonTerminal);
   }
   else {
+    //Update root graph hash in case forceNonTerminal changed.
+    rootNode->graphHashMaybeForceNonTerminal = rootNode->forceNonTerminal ? (rootGraphHash ^ FORCE_NON_TERMINAL_HASH) : rootGraphHash;
+
     //If the root node has any existing children, then prune things down if there are moves that should not be allowed at the root.
     SearchNode& node = *rootNode;
     SearchNodeChildrenReference children = node.getChildren();
@@ -814,9 +827,6 @@ uint32_t Search::createMutexIdxForNode(SearchThread& thread) const {
   return thread.rand.nextUInt() & (mutexPool->getNumMutexes()-1);
 }
 
-//Based on sha256 of "search.cpp FORCE_NON_TERMINAL_HASH"
-static const Hash128 FORCE_NON_TERMINAL_HASH = Hash128(0xd4c31800cb8809e2ULL,0xf75f9d2083f2ffcaULL);
-
 //Must be called AFTER making the bestChildMoveLoc in the thread board and hist.
 SearchNode* Search::allocateOrFindNode(SearchThread& thread, Player nextPla, Loc bestChildMoveLoc, bool forceNonTerminal, Hash128 graphHash) {
   //Hash to use as a unique id for this node in the table, for transposition detection.
@@ -850,7 +860,7 @@ SearchNode* Search::allocateOrFindNode(SearchThread& thread, Player nextPla, Loc
       child = insertLoc->second;
     }
     else {
-      child = new SearchNode(nextPla, forceNonTerminal, createMutexIdxForNode(thread));
+      child = new SearchNode(nextPla, forceNonTerminal, createMutexIdxForNode(thread), childHash);
 
       //Also perform subtree value bias and pattern bonus handling under the mutex. These parameters are no atomic, so
       //if the node is accessed concurrently by other nodes through the table, we need to make sure these parameters are fully
@@ -1080,12 +1090,6 @@ void Search::computeRootValues() {
     if(recentScoreCenter < expectedScore - cap)
       recentScoreCenter = expectedScore - cap;
   }
-
-  //If we're using graph search, we recompute the graph hash from scratch at the start of search.
-  if(searchParams.useGraphSearch)
-    rootGraphHash = GraphHash::getGraphHashFromScratch(rootHistory, rootPla, searchParams.graphSearchRepBound, searchParams.drawEquivalentWinsForWhite);
-  else
-    rootGraphHash = Hash128();
 
   Player opponentWasMirroringPla = mirroringPla;
   //Update mirroringPla, mirrorAdvantage, mirrorCenterSymmetryError

--- a/cpp/search/search.h
+++ b/cpp/search/search.h
@@ -15,6 +15,7 @@
 #include "../game/rules.h"
 #include "../neuralnet/nneval.h"
 #include "../search/analysisdata.h"
+#include "../search/evalcache.h"
 #include "../search/mutexpool.h"
 #include "../search/reportedsearchvalues.h"
 #include "../search/searchparams.h"
@@ -136,6 +137,8 @@ struct Search {
   //Implicitly these utility adjustments "assume" the opponent likes the negative of our adjustments.
   PatternBonusTable* patternBonusTable;
   std::unique_ptr<PatternBonusTable> externalPatternBonusTable;
+
+  EvalCacheTable* evalCache;
 
   Rand nonSearchRand; //only for use not in search, since rand isn't threadsafe
 
@@ -616,6 +619,17 @@ private:
   void updateStatsAfterPlayout(SearchNode& node, SearchThread& thread, bool isRoot);
   void recomputeNodeStats(SearchNode& node, SearchThread& thread, int32_t numVisitsToAdd, bool isRoot);
 
+  void adjustEvalsFromCacheHelper(
+    EvalCacheEntry* evalCacheEntry,
+    int64_t thisNodeVisits,
+    double& winLossValueAvg,
+    double& noResultValueAvg,
+    double& scoreMeanAvg,
+    double& scoreMeanSqAvg,
+    double& leadAvg,
+    double* utilityAvg
+  );
+
   void downweightBadChildrenAndNormalizeWeight(
     int numChildren,
     double currentTotalWeight,
@@ -645,6 +659,7 @@ private:
   //----------------------------------------------------------------------------------------
   void computeRootValues(); // Helper for begin search
   void recursivelyRecomputeStats(SearchNode& node); // Helper for search initialization
+  void recursivelyRecordEvalCache(SearchNode& n);
 
   bool playoutDescend(
     SearchThread& thread, SearchNode& node,

--- a/cpp/search/searchnode.cpp
+++ b/cpp/search/searchnode.cpp
@@ -170,6 +170,7 @@ SearchNode::SearchNode(Player pla, bool fnt, uint32_t mIdx, Hash128 gh)
    lastSubtreeValueBiasWeight(0.0),
    subtreeValueBiasTableEntry(),
    graphHashMaybeForceNonTerminal(gh),
+   evalCacheEntry(NULL),
    dirtyCounter(0)
 {
 }
@@ -192,6 +193,7 @@ SearchNode::SearchNode(const SearchNode& other, bool fnt, bool copySubtreeValueB
    lastSubtreeValueBiasWeight(0.0),
    subtreeValueBiasTableEntry(),
    graphHashMaybeForceNonTerminal(other.graphHashMaybeForceNonTerminal),
+   evalCacheEntry(other.evalCacheEntry),
    dirtyCounter(other.dirtyCounter.load(std::memory_order_acquire))
 {
   {

--- a/cpp/search/searchnode.cpp
+++ b/cpp/search/searchnode.cpp
@@ -152,7 +152,7 @@ void SearchChildPointer::setMoveLocRelaxed(Loc loc) {
 
 
 //Makes a search node resulting from prevPla playing prevLoc
-SearchNode::SearchNode(Player pla, bool fnt, uint32_t mIdx)
+SearchNode::SearchNode(Player pla, bool fnt, uint32_t mIdx, Hash128 gh)
   :nextPla(pla),
    forceNonTerminal(fnt),
    patternBonusHash(),
@@ -169,6 +169,7 @@ SearchNode::SearchNode(Player pla, bool fnt, uint32_t mIdx)
    lastSubtreeValueBiasDeltaSum(0.0),
    lastSubtreeValueBiasWeight(0.0),
    subtreeValueBiasTableEntry(),
+   graphHashMaybeForceNonTerminal(gh),
    dirtyCounter(0)
 {
 }
@@ -190,6 +191,7 @@ SearchNode::SearchNode(const SearchNode& other, bool fnt, bool copySubtreeValueB
    lastSubtreeValueBiasDeltaSum(0.0),
    lastSubtreeValueBiasWeight(0.0),
    subtreeValueBiasTableEntry(),
+   graphHashMaybeForceNonTerminal(other.graphHashMaybeForceNonTerminal),
    dirtyCounter(other.dirtyCounter.load(std::memory_order_acquire))
 {
   {

--- a/cpp/search/searchnode.h
+++ b/cpp/search/searchnode.h
@@ -7,6 +7,7 @@
 #include "../game/boardhistory.h"
 #include "../neuralnet/nneval.h"
 #include "../search/subtreevaluebiastable.h"
+#include "../search/evalcache.h"
 
 typedef int SearchNodeState; // See SearchNode::STATE_*
 
@@ -233,6 +234,7 @@ struct SearchNode {
   //child handles passes after a pass move, this property is not encoded in the hash!
   //On the root, this might not be up to date outside of the search regarding forceNonTerminal.
   Hash128 graphHashMaybeForceNonTerminal;
+  EvalCacheEntry* evalCacheEntry;
 
   std::atomic<int32_t> dirtyCounter;
 

--- a/cpp/search/searchnode.h
+++ b/cpp/search/searchnode.h
@@ -225,10 +225,19 @@ struct SearchNode {
   double lastSubtreeValueBiasWeight;
   std::shared_ptr<SubtreeValueBiasEntry> subtreeValueBiasTableEntry;
 
+  //Only valid if useGraphSearch is true.
+  //Graph hash of this node except with an additional factor hashed in if this node would normally be a terminal node
+  //and we are forcing it not to be due to being the root, or a child of the root after passing (if conservativePass)
+  //or after any pass in the tree that friendlyPassOk marks as should not be ending the game.
+  //Note that this is NOT a unique key for evaluations due to special behavior of the root where it affects how a
+  //child handles passes after a pass move, this property is not encoded in the hash!
+  //On the root, this might not be up to date outside of the search regarding forceNonTerminal.
+  Hash128 graphHashMaybeForceNonTerminal;
+
   std::atomic<int32_t> dirtyCounter;
 
   //--------------------------------------------------------------------------------
-  SearchNode(Player prevPla, bool forceNonTerminal, uint32_t mutexIdx);
+  SearchNode(Player prevPla, bool forceNonTerminal, uint32_t mutexIdx, Hash128 graphHashMaybeForceNonTerminal);
   SearchNode(const SearchNode&, bool forceNonTerminal, bool copySubtreeValueBias);
   ~SearchNode();
 

--- a/cpp/search/searchparams.cpp
+++ b/cpp/search/searchparams.cpp
@@ -80,6 +80,8 @@ SearchParams::SearchParams()
    subtreeValueBiasTableNumShards(65536),
    subtreeValueBiasFreeProp(0.8),
    subtreeValueBiasWeightExponent(0.5),
+   useEvalCache(false),
+   evalCacheMinVisits(100),
    nodeTableShardsPowerOfTwo(16),
    numVirtualLossesPerThread(3.0),
    numThreads(1),
@@ -210,6 +212,9 @@ bool SearchParams::operator==(const SearchParams& other) const {
     subtreeValueBiasTableNumShards == other.subtreeValueBiasTableNumShards &&
     subtreeValueBiasFreeProp == other.subtreeValueBiasFreeProp &&
     subtreeValueBiasWeightExponent == other.subtreeValueBiasWeightExponent &&
+
+    useEvalCache == other.useEvalCache &&
+    evalCacheMinVisits == other.evalCacheMinVisits &&
 
     nodeTableShardsPowerOfTwo == other.nodeTableShardsPowerOfTwo &&
     numVirtualLossesPerThread == other.numVirtualLossesPerThread &&
@@ -457,6 +462,9 @@ json SearchParams::changeableParametersToJson() const {
   ret["subtreeValueBiasFreeProp"] = subtreeValueBiasFreeProp;
   ret["subtreeValueBiasWeightExponent"] = subtreeValueBiasWeightExponent;
 
+  ret["useEvalCache"] = useEvalCache;
+  ret["evalCacheMinVisits"] = evalCacheMinVisits;
+
   // ret["nodeTableShardsPowerOfTwo"] = nodeTableShardsPowerOfTwo;
   ret["numVirtualLossesPerThread"] = numVirtualLossesPerThread;
 
@@ -602,6 +610,8 @@ void SearchParams::printParams(std::ostream& out) const {
   PRINTPARAM(subtreeValueBiasFreeProp);
   PRINTPARAM(subtreeValueBiasWeightExponent);
 
+  PRINTPARAM(useEvalCache);
+  PRINTPARAM(evalCacheMinVisits);
 
   PRINTPARAM(nodeTableShardsPowerOfTwo);
   PRINTPARAM(numVirtualLossesPerThread);

--- a/cpp/search/searchparams.h
+++ b/cpp/search/searchparams.h
@@ -111,6 +111,9 @@ struct SearchParams {
   double subtreeValueBiasFreeProp; //When a node is no longer part of the relevant search tree, only decay this proportion of the weight.
   double subtreeValueBiasWeightExponent; //When computing empiricial bias, weight subtree results by childvisits to this power.
 
+  bool useEvalCache;
+  int64_t evalCacheMinVisits;
+
   //Threading-related
   int nodeTableShardsPowerOfTwo; //Controls number of shards of node table for graph search transposition lookup
   double numVirtualLossesPerThread; //Number of virtual losses for one thread to add

--- a/cpp/tests/results/runOutputTests.txt
+++ b/cpp/tests/results/runOutputTests.txt
@@ -17163,282 +17163,282 @@ rules koPOSITIONALscoreAREAtaxNONEsui1fpok1komi7.5
 enablePassingHacks 0 conservativePassAndIsRoot 0
 VERSION 6
 encorephase 0 finished 0 numTurnsThisPhase 0 numApproxValidTurnsThisPhase 0
-3368838144F812C6E8C96E018EB0F193
+AAA153CF896E5AB2E9DA0B58165FFBB6
 History that net sees null null null null null
 Move 0 F4
 encorephase 0 finished 0 numTurnsThisPhase 1 numApproxValidTurnsThisPhase 1
-976AC1976F689AA26CB770868ED255EB
+0EA311D9A2FED2D66DA415DF163D5FCE
 History that net sees F4 null null null null
 Move 1 E5
 encorephase 0 finished 0 numTurnsThisPhase 2 numApproxValidTurnsThisPhase 2
-BD50B761A383F835F8A4FBAF6F16532C
+2499672F6E15B041F9B79EF6F7F95909
 History that net sees E5 F4 null null null
 Move 2 D6
 encorephase 0 finished 0 numTurnsThisPhase 3 numApproxValidTurnsThisPhase 3
-D0F821301625DCF82731D2E428DD59C9
+4931F17EDBB3948C2622B7BDB03253EC
 History that net sees D6 E5 F4 null null
 Move 3 pass
 encorephase 0 finished 0 numTurnsThisPhase 4 numApproxValidTurnsThisPhase 4
-C8DFFA0442B54EB90CDC9F5C33EB601C
+51162A4A8F2306CD0DCFFA05AB046A39
 History that net sees null null null null null
 Move 4 pass
 encorephase 0 finished 1 numTurnsThisPhase 5 numApproxValidTurnsThisPhase 5
-C2389F06E895B4AB14F63FFD56399169
+5BF14F482503FCDF15E55AA4CED69B4C
 History that net sees pass null null null null
 Move 5 pass
 encorephase 0 finished 1 numTurnsThisPhase 6 numApproxValidTurnsThisPhase 2
-43896A46D42356025D752B630C66D230
+DA40BA0819B51E765C664E3A9489D815
 History that net sees pass null null null null
 Move 6 C7
 encorephase 0 finished 0 numTurnsThisPhase 7 numApproxValidTurnsThisPhase 2
-C764794E70977A4B4E86F7BB27879E02
+5EADA900BD01323F4F9592E2BF689427
 History that net sees C7 pass null null null
 Move 7 B8
 encorephase 0 finished 0 numTurnsThisPhase 8 numApproxValidTurnsThisPhase 3
-3D4E55D19ACA27E433F4D74B8FB26DB7
+A487859F575C6F9032E7B212175D6792
 History that net sees B8 C7 pass null null
 Move 8 pass
 encorephase 0 finished 0 numTurnsThisPhase 9 numApproxValidTurnsThisPhase 4
-25698EE5CE5AB5A518199AF394845462
+BCA05EAB03CCFDD1190AFFAA0C6B5E47
 History that net sees null null null null null
 Move 9 pass
 encorephase 0 finished 1 numTurnsThisPhase 10 numApproxValidTurnsThisPhase 5
-2F8EEBE7647A4FB700333A52F156A517
+B6473BA9A9EC07C301205F0B69B9AF32
 History that net sees pass null null null null
 
 rules koPOSITIONALscoreAREAtaxNONEsui1fpok1komi7.5
 enablePassingHacks 0 conservativePassAndIsRoot 0
 VERSION 7
 encorephase 0 finished 0 numTurnsThisPhase 0 numApproxValidTurnsThisPhase 0
-3368838144F812C6E8C96E018EB0F193
+AAA153CF896E5AB2E9DA0B58165FFBB6
 History that net sees null null null null null
 Move 0 F4
 encorephase 0 finished 0 numTurnsThisPhase 1 numApproxValidTurnsThisPhase 1
-976AC1976F689AA26CB770868ED255EB
+0EA311D9A2FED2D66DA415DF163D5FCE
 History that net sees F4 null null null null
 Move 1 E5
 encorephase 0 finished 0 numTurnsThisPhase 2 numApproxValidTurnsThisPhase 2
-BD50B761A383F835F8A4FBAF6F16532C
+2499672F6E15B041F9B79EF6F7F95909
 History that net sees E5 F4 null null null
 Move 2 D6
 encorephase 0 finished 0 numTurnsThisPhase 3 numApproxValidTurnsThisPhase 3
-D0F821301625DCF82731D2E428DD59C9
+4931F17EDBB3948C2622B7BDB03253EC
 History that net sees D6 E5 F4 null null
 Move 3 pass
 encorephase 0 finished 0 numTurnsThisPhase 4 numApproxValidTurnsThisPhase 4
-C8DFFA0442B54EB90CDC9F5C33EB601C
+51162A4A8F2306CD0DCFFA05AB046A39
 History that net sees null null null null null
 Move 4 pass
 encorephase 0 finished 1 numTurnsThisPhase 5 numApproxValidTurnsThisPhase 5
-C2389F06E895B4AB14F63FFD56399169
+5BF14F482503FCDF15E55AA4CED69B4C
 History that net sees pass null null null null
 Move 5 pass
 encorephase 0 finished 1 numTurnsThisPhase 6 numApproxValidTurnsThisPhase 2
-43896A46D42356025D752B630C66D230
+DA40BA0819B51E765C664E3A9489D815
 History that net sees pass null null null null
 Move 6 C7
 encorephase 0 finished 0 numTurnsThisPhase 7 numApproxValidTurnsThisPhase 2
-C764794E70977A4B4E86F7BB27879E02
+5EADA900BD01323F4F9592E2BF689427
 History that net sees C7 pass null null null
 Move 7 B8
 encorephase 0 finished 0 numTurnsThisPhase 8 numApproxValidTurnsThisPhase 3
-3D4E55D19ACA27E433F4D74B8FB26DB7
+A487859F575C6F9032E7B212175D6792
 History that net sees B8 C7 pass null null
 Move 8 pass
 encorephase 0 finished 0 numTurnsThisPhase 9 numApproxValidTurnsThisPhase 4
-25698EE5CE5AB5A518199AF394845462
+BCA05EAB03CCFDD1190AFFAA0C6B5E47
 History that net sees null null null null null
 Move 9 pass
 encorephase 0 finished 1 numTurnsThisPhase 10 numApproxValidTurnsThisPhase 5
-2F8EEBE7647A4FB700333A52F156A517
+B6473BA9A9EC07C301205F0B69B9AF32
 History that net sees pass null null null null
 
 rules koPOSITIONALscoreAREAtaxNONEsui1fpok1komi7.5
 enablePassingHacks 1 conservativePassAndIsRoot 0
 VERSION 6
 encorephase 0 finished 0 numTurnsThisPhase 0 numApproxValidTurnsThisPhase 0
-3368838144F812C6E8C96E018EB0F193
+AAA153CF896E5AB2E9DA0B58165FFBB6
 History that net sees null null null null null
 Move 0 F4
 encorephase 0 finished 0 numTurnsThisPhase 1 numApproxValidTurnsThisPhase 1
-976AC1976F689AA26CB770868ED255EB
+0EA311D9A2FED2D66DA415DF163D5FCE
 History that net sees F4 null null null null
 Move 1 E5
 encorephase 0 finished 0 numTurnsThisPhase 2 numApproxValidTurnsThisPhase 2
-BD50B761A383F835F8A4FBAF6F16532C
+2499672F6E15B041F9B79EF6F7F95909
 History that net sees E5 F4 null null null
 Move 2 D6
 encorephase 0 finished 0 numTurnsThisPhase 3 numApproxValidTurnsThisPhase 3
-D0F821301625DCF82731D2E428DD59C9
+4931F17EDBB3948C2622B7BDB03253EC
 History that net sees D6 E5 F4 null null
 Move 3 pass
 encorephase 0 finished 0 numTurnsThisPhase 4 numApproxValidTurnsThisPhase 4
-EE5360FB3B7303B990556BA10F0EC930
+779AB0B5F6E54BCD91460EF897E1C315
 History that net sees null null null null null
 Move 4 pass
 encorephase 0 finished 1 numTurnsThisPhase 5 numApproxValidTurnsThisPhase 5
-E4B405F99153F9AB887FCB006ADC3845
+7D7DD5B75CC5B1DF896CAE59F2333260
 History that net sees pass null null null null
 Move 5 pass
 encorephase 0 finished 1 numTurnsThisPhase 6 numApproxValidTurnsThisPhase 2
-6505F0B9ADE51B02C1FCDF9E30837B1C
+FCCC20F760735376C0EFBAC7A86C7139
 History that net sees null null null null null
 Move 6 C7
 encorephase 0 finished 0 numTurnsThisPhase 7 numApproxValidTurnsThisPhase 2
-C764794E70977A4B4E86F7BB27879E02
+5EADA900BD01323F4F9592E2BF689427
 History that net sees C7 pass null null null
 Move 7 B8
 encorephase 0 finished 0 numTurnsThisPhase 8 numApproxValidTurnsThisPhase 3
-3D4E55D19ACA27E433F4D74B8FB26DB7
+A487859F575C6F9032E7B212175D6792
 History that net sees B8 C7 pass null null
 Move 8 pass
 encorephase 0 finished 0 numTurnsThisPhase 9 numApproxValidTurnsThisPhase 4
-03E5141AB79CF8A584906E0EA861FD4E
+9A2CC4547A0AB0D185830B57308EF76B
 History that net sees null null null null null
 Move 9 pass
 encorephase 0 finished 1 numTurnsThisPhase 10 numApproxValidTurnsThisPhase 5
-090271181DBC02B79CBACEAFCDB30C3B
+90CBA156D02A4AC39DA9ABF6555C061E
 History that net sees null null null null null
 
 rules koPOSITIONALscoreAREAtaxNONEsui1fpok1komi7.5
 enablePassingHacks 1 conservativePassAndIsRoot 0
 VERSION 7
 encorephase 0 finished 0 numTurnsThisPhase 0 numApproxValidTurnsThisPhase 0
-3368838144F812C6E8C96E018EB0F193
+AAA153CF896E5AB2E9DA0B58165FFBB6
 History that net sees null null null null null
 Move 0 F4
 encorephase 0 finished 0 numTurnsThisPhase 1 numApproxValidTurnsThisPhase 1
-976AC1976F689AA26CB770868ED255EB
+0EA311D9A2FED2D66DA415DF163D5FCE
 History that net sees F4 null null null null
 Move 1 E5
 encorephase 0 finished 0 numTurnsThisPhase 2 numApproxValidTurnsThisPhase 2
-BD50B761A383F835F8A4FBAF6F16532C
+2499672F6E15B041F9B79EF6F7F95909
 History that net sees E5 F4 null null null
 Move 2 D6
 encorephase 0 finished 0 numTurnsThisPhase 3 numApproxValidTurnsThisPhase 3
-D0F821301625DCF82731D2E428DD59C9
+4931F17EDBB3948C2622B7BDB03253EC
 History that net sees D6 E5 F4 null null
 Move 3 pass
 encorephase 0 finished 0 numTurnsThisPhase 4 numApproxValidTurnsThisPhase 4
-EE5360FB3B7303B990556BA10F0EC930
+779AB0B5F6E54BCD91460EF897E1C315
 History that net sees null null null null null
 Move 4 pass
 encorephase 0 finished 1 numTurnsThisPhase 5 numApproxValidTurnsThisPhase 5
-E4B405F99153F9AB887FCB006ADC3845
+7D7DD5B75CC5B1DF896CAE59F2333260
 History that net sees pass null null null null
 Move 5 pass
 encorephase 0 finished 1 numTurnsThisPhase 6 numApproxValidTurnsThisPhase 2
-6505F0B9ADE51B02C1FCDF9E30837B1C
+FCCC20F760735376C0EFBAC7A86C7139
 History that net sees null null null null null
 Move 6 C7
 encorephase 0 finished 0 numTurnsThisPhase 7 numApproxValidTurnsThisPhase 2
-C764794E70977A4B4E86F7BB27879E02
+5EADA900BD01323F4F9592E2BF689427
 History that net sees C7 pass null null null
 Move 7 B8
 encorephase 0 finished 0 numTurnsThisPhase 8 numApproxValidTurnsThisPhase 3
-3D4E55D19ACA27E433F4D74B8FB26DB7
+A487859F575C6F9032E7B212175D6792
 History that net sees B8 C7 pass null null
 Move 8 pass
 encorephase 0 finished 0 numTurnsThisPhase 9 numApproxValidTurnsThisPhase 4
-03E5141AB79CF8A584906E0EA861FD4E
+9A2CC4547A0AB0D185830B57308EF76B
 History that net sees null null null null null
 Move 9 pass
 encorephase 0 finished 1 numTurnsThisPhase 10 numApproxValidTurnsThisPhase 5
-090271181DBC02B79CBACEAFCDB30C3B
+90CBA156D02A4AC39DA9ABF6555C061E
 History that net sees null null null null null
 
 rules koPOSITIONALscoreAREAtaxNONEsui1fpok1komi7.5
 enablePassingHacks 1 conservativePassAndIsRoot 1
 VERSION 6
 encorephase 0 finished 0 numTurnsThisPhase 0 numApproxValidTurnsThisPhase 0
-3368838144F812C6E8C96E018EB0F193
+AAA153CF896E5AB2E9DA0B58165FFBB6
 History that net sees null null null null null
 Move 0 F4
 encorephase 0 finished 0 numTurnsThisPhase 1 numApproxValidTurnsThisPhase 1
-976AC1976F689AA26CB770868ED255EB
+0EA311D9A2FED2D66DA415DF163D5FCE
 History that net sees F4 null null null null
 Move 1 E5
 encorephase 0 finished 0 numTurnsThisPhase 2 numApproxValidTurnsThisPhase 2
-BD50B761A383F835F8A4FBAF6F16532C
+2499672F6E15B041F9B79EF6F7F95909
 History that net sees E5 F4 null null null
 Move 2 D6
 encorephase 0 finished 0 numTurnsThisPhase 3 numApproxValidTurnsThisPhase 3
-D0F821301625DCF82731D2E428DD59C9
+4931F17EDBB3948C2622B7BDB03253EC
 History that net sees D6 E5 F4 null null
 Move 3 pass
 encorephase 0 finished 0 numTurnsThisPhase 4 numApproxValidTurnsThisPhase 4
-B447BE19338DC3549C7EFD55B7A0E499
+2D8E6E57FE1B8B209D6D980C2F4FEEBC
 History that net sees null null null null null
 Move 4 pass
 encorephase 0 finished 1 numTurnsThisPhase 5 numApproxValidTurnsThisPhase 5
-BEA0DB1B99AD394684545DF4D27215EC
+27690B55543B7132854738AD4A9D1FC9
 History that net sees null null null null null
 Move 5 pass
 encorephase 0 finished 1 numTurnsThisPhase 6 numApproxValidTurnsThisPhase 2
-3F112E5BA51BDBEFCDD7496A882D56B5
+A6D8FE15688D939BCCC42C3310C25C90
 History that net sees null null null null null
 Move 6 C7
 encorephase 0 finished 0 numTurnsThisPhase 7 numApproxValidTurnsThisPhase 2
-C764794E70977A4B4E86F7BB27879E02
+5EADA900BD01323F4F9592E2BF689427
 History that net sees C7 pass null null null
 Move 7 B8
 encorephase 0 finished 0 numTurnsThisPhase 8 numApproxValidTurnsThisPhase 3
-3D4E55D19ACA27E433F4D74B8FB26DB7
+A487859F575C6F9032E7B212175D6792
 History that net sees B8 C7 pass null null
 Move 8 pass
 encorephase 0 finished 0 numTurnsThisPhase 9 numApproxValidTurnsThisPhase 4
-59F1CAF8BF62384888BBF8FA10CFD0E7
+C0381AB672F4703C89A89DA38820DAC2
 History that net sees null null null null null
 Move 9 pass
 encorephase 0 finished 1 numTurnsThisPhase 10 numApproxValidTurnsThisPhase 5
-5316AFFA1542C25A9091585B751D2192
+CADF7FB4D8D48A2E91823D02EDF22BB7
 History that net sees null null null null null
 
 rules koPOSITIONALscoreAREAtaxNONEsui1fpok1komi7.5
 enablePassingHacks 1 conservativePassAndIsRoot 1
 VERSION 7
 encorephase 0 finished 0 numTurnsThisPhase 0 numApproxValidTurnsThisPhase 0
-3368838144F812C6E8C96E018EB0F193
+AAA153CF896E5AB2E9DA0B58165FFBB6
 History that net sees null null null null null
 Move 0 F4
 encorephase 0 finished 0 numTurnsThisPhase 1 numApproxValidTurnsThisPhase 1
-976AC1976F689AA26CB770868ED255EB
+0EA311D9A2FED2D66DA415DF163D5FCE
 History that net sees F4 null null null null
 Move 1 E5
 encorephase 0 finished 0 numTurnsThisPhase 2 numApproxValidTurnsThisPhase 2
-BD50B761A383F835F8A4FBAF6F16532C
+2499672F6E15B041F9B79EF6F7F95909
 History that net sees E5 F4 null null null
 Move 2 D6
 encorephase 0 finished 0 numTurnsThisPhase 3 numApproxValidTurnsThisPhase 3
-D0F821301625DCF82731D2E428DD59C9
+4931F17EDBB3948C2622B7BDB03253EC
 History that net sees D6 E5 F4 null null
 Move 3 pass
 encorephase 0 finished 0 numTurnsThisPhase 4 numApproxValidTurnsThisPhase 4
-B447BE19338DC3549C7EFD55B7A0E499
+2D8E6E57FE1B8B209D6D980C2F4FEEBC
 History that net sees null null null null null
 Move 4 pass
 encorephase 0 finished 1 numTurnsThisPhase 5 numApproxValidTurnsThisPhase 5
-BEA0DB1B99AD394684545DF4D27215EC
+27690B55543B7132854738AD4A9D1FC9
 History that net sees null null null null null
 Move 5 pass
 encorephase 0 finished 1 numTurnsThisPhase 6 numApproxValidTurnsThisPhase 2
-3F112E5BA51BDBEFCDD7496A882D56B5
+A6D8FE15688D939BCCC42C3310C25C90
 History that net sees null null null null null
 Move 6 C7
 encorephase 0 finished 0 numTurnsThisPhase 7 numApproxValidTurnsThisPhase 2
-C764794E70977A4B4E86F7BB27879E02
+5EADA900BD01323F4F9592E2BF689427
 History that net sees C7 pass null null null
 Move 7 B8
 encorephase 0 finished 0 numTurnsThisPhase 8 numApproxValidTurnsThisPhase 3
-3D4E55D19ACA27E433F4D74B8FB26DB7
+A487859F575C6F9032E7B212175D6792
 History that net sees B8 C7 pass null null
 Move 8 pass
 encorephase 0 finished 0 numTurnsThisPhase 9 numApproxValidTurnsThisPhase 4
-59F1CAF8BF62384888BBF8FA10CFD0E7
+C0381AB672F4703C89A89DA38820DAC2
 History that net sees null null null null null
 Move 9 pass
 encorephase 0 finished 1 numTurnsThisPhase 10 numApproxValidTurnsThisPhase 5
-5316AFFA1542C25A9091585B751D2192
+CADF7FB4D8D48A2E91823D02EDF22BB7
 History that net sees null null null null null
 
 (;GM[1]FF[4]SZ[9]KM[-7];B[ff];W[ee];B[dd];W[];B[];W[];B[cc];W[bb];B[];W[])
@@ -17446,282 +17446,282 @@ rules koPOSITIONALscoreAREAtaxNONEsui1fpok1komi7.5
 enablePassingHacks 0 conservativePassAndIsRoot 0
 VERSION 6
 encorephase 0 finished 0 numTurnsThisPhase 0 numApproxValidTurnsThisPhase 0
-EB329DDC6A3797B25D5FC605CCFA71CF
+72FB4D92A7A1DFC65C4CA35C54157BEA
 History that net sees null null null null null
 Move 0 F4
 encorephase 0 finished 0 numTurnsThisPhase 1 numApproxValidTurnsThisPhase 1
-4F30DFCA41A71FD6D921D882CC98D5B7
+D6F90F848C3157A2D832BDDB5477DF92
 History that net sees F4 null null null null
 Move 1 E5
 encorephase 0 finished 0 numTurnsThisPhase 2 numApproxValidTurnsThisPhase 2
-650AA93C8D4C7D414D3253AB2D5CD370
+FCC3797240DA35354C2136F2B5B3D955
 History that net sees E5 F4 null null null
 Move 2 D6
 encorephase 0 finished 0 numTurnsThisPhase 3 numApproxValidTurnsThisPhase 3
-08A23F6D38EA598C92A77AE06A97D995
+916BEF23F57C11F893B41FB9F278D3B0
 History that net sees D6 E5 F4 null null
 Move 3 pass
 encorephase 0 finished 0 numTurnsThisPhase 4 numApproxValidTurnsThisPhase 4
-1085E4596C7ACBCDB94A375871A1E040
+894C3417A1EC83B9B8595201E94EEA65
 History that net sees null null null null null
 Move 4 pass
 encorephase 0 finished 1 numTurnsThisPhase 5 numApproxValidTurnsThisPhase 5
-1A62815BC65A31DFA16097F914731135
+83AB51150BCC79ABA073F2A08C9C1B10
 History that net sees pass null null null null
 Move 5 pass
 encorephase 0 finished 1 numTurnsThisPhase 6 numApproxValidTurnsThisPhase 2
-9BD3741BFAECD376E8E383674E2C526C
+021AA455377A9B02E9F0E63ED6C35849
 History that net sees pass null null null null
 Move 6 C7
 encorephase 0 finished 0 numTurnsThisPhase 7 numApproxValidTurnsThisPhase 2
-1F3E67135E58FF3FFB105FBF65CD1E5E
+86F7B75D93CEB74BFA033AE6FD22147B
 History that net sees C7 pass null null null
 Move 7 B8
 encorephase 0 finished 0 numTurnsThisPhase 8 numApproxValidTurnsThisPhase 3
-E5144B8CB405A29086627F4FCDF8EDEB
+7CDD9BC27993EAE487711A165517E7CE
 History that net sees B8 C7 pass null null
 Move 8 pass
 encorephase 0 finished 0 numTurnsThisPhase 9 numApproxValidTurnsThisPhase 4
-FD3390B8E09530D1AD8F32F7D6CED43E
+64FA40F62D0378A5AC9C57AE4E21DE1B
 History that net sees null null null null null
 Move 9 pass
 encorephase 0 finished 1 numTurnsThisPhase 10 numApproxValidTurnsThisPhase 5
-F7D4F5BA4AB5CAC3B5A59256B31C254B
+6E1D25F4872382B7B4B6F70F2BF32F6E
 History that net sees pass null null null null
 
 rules koPOSITIONALscoreAREAtaxNONEsui1fpok1komi7.5
 enablePassingHacks 0 conservativePassAndIsRoot 0
 VERSION 7
 encorephase 0 finished 0 numTurnsThisPhase 0 numApproxValidTurnsThisPhase 0
-EB329DDC6A3797B25D5FC605CCFA71CF
+72FB4D92A7A1DFC65C4CA35C54157BEA
 History that net sees null null null null null
 Move 0 F4
 encorephase 0 finished 0 numTurnsThisPhase 1 numApproxValidTurnsThisPhase 1
-4F30DFCA41A71FD6D921D882CC98D5B7
+D6F90F848C3157A2D832BDDB5477DF92
 History that net sees F4 null null null null
 Move 1 E5
 encorephase 0 finished 0 numTurnsThisPhase 2 numApproxValidTurnsThisPhase 2
-650AA93C8D4C7D414D3253AB2D5CD370
+FCC3797240DA35354C2136F2B5B3D955
 History that net sees E5 F4 null null null
 Move 2 D6
 encorephase 0 finished 0 numTurnsThisPhase 3 numApproxValidTurnsThisPhase 3
-08A23F6D38EA598C92A77AE06A97D995
+916BEF23F57C11F893B41FB9F278D3B0
 History that net sees D6 E5 F4 null null
 Move 3 pass
 encorephase 0 finished 0 numTurnsThisPhase 4 numApproxValidTurnsThisPhase 4
-1085E4596C7ACBCDB94A375871A1E040
+894C3417A1EC83B9B8595201E94EEA65
 History that net sees null null null null null
 Move 4 pass
 encorephase 0 finished 1 numTurnsThisPhase 5 numApproxValidTurnsThisPhase 5
-1A62815BC65A31DFA16097F914731135
+83AB51150BCC79ABA073F2A08C9C1B10
 History that net sees pass null null null null
 Move 5 pass
 encorephase 0 finished 1 numTurnsThisPhase 6 numApproxValidTurnsThisPhase 2
-9BD3741BFAECD376E8E383674E2C526C
+021AA455377A9B02E9F0E63ED6C35849
 History that net sees pass null null null null
 Move 6 C7
 encorephase 0 finished 0 numTurnsThisPhase 7 numApproxValidTurnsThisPhase 2
-1F3E67135E58FF3FFB105FBF65CD1E5E
+86F7B75D93CEB74BFA033AE6FD22147B
 History that net sees C7 pass null null null
 Move 7 B8
 encorephase 0 finished 0 numTurnsThisPhase 8 numApproxValidTurnsThisPhase 3
-E5144B8CB405A29086627F4FCDF8EDEB
+7CDD9BC27993EAE487711A165517E7CE
 History that net sees B8 C7 pass null null
 Move 8 pass
 encorephase 0 finished 0 numTurnsThisPhase 9 numApproxValidTurnsThisPhase 4
-FD3390B8E09530D1AD8F32F7D6CED43E
+64FA40F62D0378A5AC9C57AE4E21DE1B
 History that net sees null null null null null
 Move 9 pass
 encorephase 0 finished 1 numTurnsThisPhase 10 numApproxValidTurnsThisPhase 5
-F7D4F5BA4AB5CAC3B5A59256B31C254B
+6E1D25F4872382B7B4B6F70F2BF32F6E
 History that net sees pass null null null null
 
 rules koPOSITIONALscoreAREAtaxNONEsui1fpok1komi7.5
 enablePassingHacks 1 conservativePassAndIsRoot 0
 VERSION 6
 encorephase 0 finished 0 numTurnsThisPhase 0 numApproxValidTurnsThisPhase 0
-EB329DDC6A3797B25D5FC605CCFA71CF
+72FB4D92A7A1DFC65C4CA35C54157BEA
 History that net sees null null null null null
 Move 0 F4
 encorephase 0 finished 0 numTurnsThisPhase 1 numApproxValidTurnsThisPhase 1
-4F30DFCA41A71FD6D921D882CC98D5B7
+D6F90F848C3157A2D832BDDB5477DF92
 History that net sees F4 null null null null
 Move 1 E5
 encorephase 0 finished 0 numTurnsThisPhase 2 numApproxValidTurnsThisPhase 2
-650AA93C8D4C7D414D3253AB2D5CD370
+FCC3797240DA35354C2136F2B5B3D955
 History that net sees E5 F4 null null null
 Move 2 D6
 encorephase 0 finished 0 numTurnsThisPhase 3 numApproxValidTurnsThisPhase 3
-08A23F6D38EA598C92A77AE06A97D995
+916BEF23F57C11F893B41FB9F278D3B0
 History that net sees D6 E5 F4 null null
 Move 3 pass
 encorephase 0 finished 0 numTurnsThisPhase 4 numApproxValidTurnsThisPhase 4
-36097EA615BC86CD25C3C3A54D44496C
+AFC0AEE8D82ACEB924D0A6FCD5AB4349
 History that net sees null null null null null
 Move 4 pass
 encorephase 0 finished 1 numTurnsThisPhase 5 numApproxValidTurnsThisPhase 5
-3CEE1BA4BF9C7CDF3DE963042896B819
+A527CBEA720A34AB3CFA065DB079B23C
 History that net sees null null null null null
 Move 5 pass
 encorephase 0 finished 1 numTurnsThisPhase 6 numApproxValidTurnsThisPhase 2
-BD5FEEE4832A9E76746A779A72C9FB40
+24963EAA4EBCD602757912C3EA26F165
 History that net sees pass null null null null
 Move 6 C7
 encorephase 0 finished 0 numTurnsThisPhase 7 numApproxValidTurnsThisPhase 2
-1F3E67135E58FF3FFB105FBF65CD1E5E
+86F7B75D93CEB74BFA033AE6FD22147B
 History that net sees C7 pass null null null
 Move 7 B8
 encorephase 0 finished 0 numTurnsThisPhase 8 numApproxValidTurnsThisPhase 3
-E5144B8CB405A29086627F4FCDF8EDEB
+7CDD9BC27993EAE487711A165517E7CE
 History that net sees B8 C7 pass null null
 Move 8 pass
 encorephase 0 finished 0 numTurnsThisPhase 9 numApproxValidTurnsThisPhase 4
-DBBF0A4799537DD13106C60AEA2B7D12
+4276DA0954C535A53015A35372C47737
 History that net sees null null null null null
 Move 9 pass
 encorephase 0 finished 1 numTurnsThisPhase 10 numApproxValidTurnsThisPhase 5
-D1586F45337387C3292C66AB8FF98C67
+4891BF0BFEE5CFB7283F03F217168642
 History that net sees pass null null null null
 
 rules koPOSITIONALscoreAREAtaxNONEsui1fpok1komi7.5
 enablePassingHacks 1 conservativePassAndIsRoot 0
 VERSION 7
 encorephase 0 finished 0 numTurnsThisPhase 0 numApproxValidTurnsThisPhase 0
-EB329DDC6A3797B25D5FC605CCFA71CF
+72FB4D92A7A1DFC65C4CA35C54157BEA
 History that net sees null null null null null
 Move 0 F4
 encorephase 0 finished 0 numTurnsThisPhase 1 numApproxValidTurnsThisPhase 1
-4F30DFCA41A71FD6D921D882CC98D5B7
+D6F90F848C3157A2D832BDDB5477DF92
 History that net sees F4 null null null null
 Move 1 E5
 encorephase 0 finished 0 numTurnsThisPhase 2 numApproxValidTurnsThisPhase 2
-650AA93C8D4C7D414D3253AB2D5CD370
+FCC3797240DA35354C2136F2B5B3D955
 History that net sees E5 F4 null null null
 Move 2 D6
 encorephase 0 finished 0 numTurnsThisPhase 3 numApproxValidTurnsThisPhase 3
-08A23F6D38EA598C92A77AE06A97D995
+916BEF23F57C11F893B41FB9F278D3B0
 History that net sees D6 E5 F4 null null
 Move 3 pass
 encorephase 0 finished 0 numTurnsThisPhase 4 numApproxValidTurnsThisPhase 4
-36097EA615BC86CD25C3C3A54D44496C
+AFC0AEE8D82ACEB924D0A6FCD5AB4349
 History that net sees null null null null null
 Move 4 pass
 encorephase 0 finished 1 numTurnsThisPhase 5 numApproxValidTurnsThisPhase 5
-3CEE1BA4BF9C7CDF3DE963042896B819
+A527CBEA720A34AB3CFA065DB079B23C
 History that net sees null null null null null
 Move 5 pass
 encorephase 0 finished 1 numTurnsThisPhase 6 numApproxValidTurnsThisPhase 2
-BD5FEEE4832A9E76746A779A72C9FB40
+24963EAA4EBCD602757912C3EA26F165
 History that net sees pass null null null null
 Move 6 C7
 encorephase 0 finished 0 numTurnsThisPhase 7 numApproxValidTurnsThisPhase 2
-1F3E67135E58FF3FFB105FBF65CD1E5E
+86F7B75D93CEB74BFA033AE6FD22147B
 History that net sees C7 pass null null null
 Move 7 B8
 encorephase 0 finished 0 numTurnsThisPhase 8 numApproxValidTurnsThisPhase 3
-E5144B8CB405A29086627F4FCDF8EDEB
+7CDD9BC27993EAE487711A165517E7CE
 History that net sees B8 C7 pass null null
 Move 8 pass
 encorephase 0 finished 0 numTurnsThisPhase 9 numApproxValidTurnsThisPhase 4
-DBBF0A4799537DD13106C60AEA2B7D12
+4276DA0954C535A53015A35372C47737
 History that net sees null null null null null
 Move 9 pass
 encorephase 0 finished 1 numTurnsThisPhase 10 numApproxValidTurnsThisPhase 5
-D1586F45337387C3292C66AB8FF98C67
+4891BF0BFEE5CFB7283F03F217168642
 History that net sees pass null null null null
 
 rules koPOSITIONALscoreAREAtaxNONEsui1fpok1komi7.5
 enablePassingHacks 1 conservativePassAndIsRoot 1
 VERSION 6
 encorephase 0 finished 0 numTurnsThisPhase 0 numApproxValidTurnsThisPhase 0
-EB329DDC6A3797B25D5FC605CCFA71CF
+72FB4D92A7A1DFC65C4CA35C54157BEA
 History that net sees null null null null null
 Move 0 F4
 encorephase 0 finished 0 numTurnsThisPhase 1 numApproxValidTurnsThisPhase 1
-4F30DFCA41A71FD6D921D882CC98D5B7
+D6F90F848C3157A2D832BDDB5477DF92
 History that net sees F4 null null null null
 Move 1 E5
 encorephase 0 finished 0 numTurnsThisPhase 2 numApproxValidTurnsThisPhase 2
-650AA93C8D4C7D414D3253AB2D5CD370
+FCC3797240DA35354C2136F2B5B3D955
 History that net sees E5 F4 null null null
 Move 2 D6
 encorephase 0 finished 0 numTurnsThisPhase 3 numApproxValidTurnsThisPhase 3
-08A23F6D38EA598C92A77AE06A97D995
+916BEF23F57C11F893B41FB9F278D3B0
 History that net sees D6 E5 F4 null null
 Move 3 pass
 encorephase 0 finished 0 numTurnsThisPhase 4 numApproxValidTurnsThisPhase 4
-6C1DA0441D42462029E85551F5EA64C5
+F5D4700AD0D40E5428FB30086D056EE0
 History that net sees null null null null null
 Move 4 pass
 encorephase 0 finished 1 numTurnsThisPhase 5 numApproxValidTurnsThisPhase 5
-66FAC546B762BC3231C2F5F0903895B0
+FF3315087AF4F44630D190A908D79F95
 History that net sees null null null null null
 Move 5 pass
 encorephase 0 finished 1 numTurnsThisPhase 6 numApproxValidTurnsThisPhase 2
-E74B30068BD45E9B7841E16ECA67D6E9
+7E82E048464216EF795284375288DCCC
 History that net sees null null null null null
 Move 6 C7
 encorephase 0 finished 0 numTurnsThisPhase 7 numApproxValidTurnsThisPhase 2
-1F3E67135E58FF3FFB105FBF65CD1E5E
+86F7B75D93CEB74BFA033AE6FD22147B
 History that net sees C7 pass null null null
 Move 7 B8
 encorephase 0 finished 0 numTurnsThisPhase 8 numApproxValidTurnsThisPhase 3
-E5144B8CB405A29086627F4FCDF8EDEB
+7CDD9BC27993EAE487711A165517E7CE
 History that net sees B8 C7 pass null null
 Move 8 pass
 encorephase 0 finished 0 numTurnsThisPhase 9 numApproxValidTurnsThisPhase 4
-81ABD4A591ADBD3C3D2D50FE528550BB
+186204EB5C3BF5483C3E35A7CA6A5A9E
 History that net sees null null null null null
 Move 9 pass
 encorephase 0 finished 1 numTurnsThisPhase 10 numApproxValidTurnsThisPhase 5
-8B4CB1A73B8D472E2507F05F3757A1CE
+128561E9F61B0F5A24149506AFB8ABEB
 History that net sees null null null null null
 
 rules koPOSITIONALscoreAREAtaxNONEsui1fpok1komi7.5
 enablePassingHacks 1 conservativePassAndIsRoot 1
 VERSION 7
 encorephase 0 finished 0 numTurnsThisPhase 0 numApproxValidTurnsThisPhase 0
-EB329DDC6A3797B25D5FC605CCFA71CF
+72FB4D92A7A1DFC65C4CA35C54157BEA
 History that net sees null null null null null
 Move 0 F4
 encorephase 0 finished 0 numTurnsThisPhase 1 numApproxValidTurnsThisPhase 1
-4F30DFCA41A71FD6D921D882CC98D5B7
+D6F90F848C3157A2D832BDDB5477DF92
 History that net sees F4 null null null null
 Move 1 E5
 encorephase 0 finished 0 numTurnsThisPhase 2 numApproxValidTurnsThisPhase 2
-650AA93C8D4C7D414D3253AB2D5CD370
+FCC3797240DA35354C2136F2B5B3D955
 History that net sees E5 F4 null null null
 Move 2 D6
 encorephase 0 finished 0 numTurnsThisPhase 3 numApproxValidTurnsThisPhase 3
-08A23F6D38EA598C92A77AE06A97D995
+916BEF23F57C11F893B41FB9F278D3B0
 History that net sees D6 E5 F4 null null
 Move 3 pass
 encorephase 0 finished 0 numTurnsThisPhase 4 numApproxValidTurnsThisPhase 4
-6C1DA0441D42462029E85551F5EA64C5
+F5D4700AD0D40E5428FB30086D056EE0
 History that net sees null null null null null
 Move 4 pass
 encorephase 0 finished 1 numTurnsThisPhase 5 numApproxValidTurnsThisPhase 5
-66FAC546B762BC3231C2F5F0903895B0
+FF3315087AF4F44630D190A908D79F95
 History that net sees null null null null null
 Move 5 pass
 encorephase 0 finished 1 numTurnsThisPhase 6 numApproxValidTurnsThisPhase 2
-E74B30068BD45E9B7841E16ECA67D6E9
+7E82E048464216EF795284375288DCCC
 History that net sees null null null null null
 Move 6 C7
 encorephase 0 finished 0 numTurnsThisPhase 7 numApproxValidTurnsThisPhase 2
-1F3E67135E58FF3FFB105FBF65CD1E5E
+86F7B75D93CEB74BFA033AE6FD22147B
 History that net sees C7 pass null null null
 Move 7 B8
 encorephase 0 finished 0 numTurnsThisPhase 8 numApproxValidTurnsThisPhase 3
-E5144B8CB405A29086627F4FCDF8EDEB
+7CDD9BC27993EAE487711A165517E7CE
 History that net sees B8 C7 pass null null
 Move 8 pass
 encorephase 0 finished 0 numTurnsThisPhase 9 numApproxValidTurnsThisPhase 4
-81ABD4A591ADBD3C3D2D50FE528550BB
+186204EB5C3BF5483C3E35A7CA6A5A9E
 History that net sees null null null null null
 Move 9 pass
 encorephase 0 finished 1 numTurnsThisPhase 10 numApproxValidTurnsThisPhase 5
-8B4CB1A73B8D472E2507F05F3757A1CE
+128561E9F61B0F5A24149506AFB8ABEB
 History that net sees null null null null null
 
 Running neuralnetless search tests

--- a/cpp/tests/results/runOutputTests.txt
+++ b/cpp/tests/results/runOutputTests.txt
@@ -20635,6 +20635,8 @@ subtreeValueBiasFactor: 0
 subtreeValueBiasTableNumShards: 65536
 subtreeValueBiasFreeProp: 0.8
 subtreeValueBiasWeightExponent: 0.5
+useEvalCache: 0
+evalCacheMinVisits: 100
 nodeTableShardsPowerOfTwo: 16
 numVirtualLossesPerThread: 3
 numThreads: 1
@@ -20741,6 +20743,8 @@ subtreeValueBiasFactor: 0
 subtreeValueBiasTableNumShards: 65536
 subtreeValueBiasFreeProp: 0.8
 subtreeValueBiasWeightExponent: 0.5
+useEvalCache: 0
+evalCacheMinVisits: 100
 nodeTableShardsPowerOfTwo: 16
 numVirtualLossesPerThread: 3
 numThreads: 1
@@ -20847,6 +20851,8 @@ subtreeValueBiasFactor: 0.45
 subtreeValueBiasTableNumShards: 65536
 subtreeValueBiasFreeProp: 0.8
 subtreeValueBiasWeightExponent: 0.85
+useEvalCache: 0
+evalCacheMinVisits: 100
 nodeTableShardsPowerOfTwo: 16
 numVirtualLossesPerThread: 1
 numThreads: 1
@@ -20953,6 +20959,8 @@ subtreeValueBiasFactor: 0.45
 subtreeValueBiasTableNumShards: 65536
 subtreeValueBiasFreeProp: 0.8
 subtreeValueBiasWeightExponent: 0.85
+useEvalCache: 0
+evalCacheMinVisits: 100
 nodeTableShardsPowerOfTwo: 16
 numVirtualLossesPerThread: 1
 numThreads: 1
@@ -21059,6 +21067,8 @@ subtreeValueBiasFactor: 0.45
 subtreeValueBiasTableNumShards: 65536
 subtreeValueBiasFreeProp: 0.8
 subtreeValueBiasWeightExponent: 0.85
+useEvalCache: 0
+evalCacheMinVisits: 100
 nodeTableShardsPowerOfTwo: 16
 numVirtualLossesPerThread: 1
 numThreads: 1
@@ -21165,6 +21175,8 @@ subtreeValueBiasFactor: 0.45
 subtreeValueBiasTableNumShards: 65536
 subtreeValueBiasFreeProp: 0.8
 subtreeValueBiasWeightExponent: 0.85
+useEvalCache: 0
+evalCacheMinVisits: 100
 nodeTableShardsPowerOfTwo: 16
 numVirtualLossesPerThread: 1
 numThreads: 1
@@ -21271,6 +21283,8 @@ subtreeValueBiasFactor: 0.45
 subtreeValueBiasTableNumShards: 65536
 subtreeValueBiasFreeProp: 0.8
 subtreeValueBiasWeightExponent: 0.85
+useEvalCache: 0
+evalCacheMinVisits: 100
 nodeTableShardsPowerOfTwo: 16
 numVirtualLossesPerThread: 1
 numThreads: 1
@@ -21377,6 +21391,8 @@ subtreeValueBiasFactor: 0.45
 subtreeValueBiasTableNumShards: 65536
 subtreeValueBiasFreeProp: 0.8
 subtreeValueBiasWeightExponent: 0.85
+useEvalCache: 0
+evalCacheMinVisits: 100
 nodeTableShardsPowerOfTwo: 16
 numVirtualLossesPerThread: 1
 numThreads: 1


### PR DESCRIPTION
Experimental branch with an option (`useEvalCache=true`) that caches evals of nodes greater than a configurable number of visits (`evalCacheMinVisits`) and remembers them permanently for the duration of that running instance of KataGo, to bias subsequent searches of the same positions to converge to the correct answer faster.

Right now there is no way to clear this cache other than restarting KataGo, and there is no way to save the cache to disk in order to reuse it on a subsequent run. These are things that could be added if this were made into a proper feature.