### PR TITLE
Allow playing cleanup moves with rootPruneUselessMoves.

### DIFF
--- a/cpp/search/searchhelpers.cpp
+++ b/cpp/search/searchhelpers.cpp
@@ -313,7 +313,8 @@ bool Search::isAllowedRootMove(Loc moveLoc) const {
   //A bad situation that can happen that unnecessarily prolongs training games is where one player
   //repeatedly passes and the other side repeatedly fills the opponent's space and/or suicides over and over.
   //To mitigate some of this and save computation, we make it so that at the root, if the last four moves by the opponent
-  //were passes, we will never play a move in either player's pass-alive area. In theory this could prune
+  //were passes, we will never play a move in either player's pass-alive area. We make an exception for playing in
+  //own territory next to opponent's stones, since that is needed for cleanup. In theory this could prune
   //a good move in situations like https://senseis.xmp.net/?1EyeFlaw, but this should be extraordinarly rare,
   if(searchParams.rootPruneUselessMoves &&
      rootHistory.moveHistory.size() > 0 &&
@@ -330,7 +331,9 @@ bool Search::isAllowedRootMove(Loc moveLoc) const {
        rootHistory.moveHistory[lastIdx-2].pla == opp &&
        rootHistory.moveHistory[lastIdx-4].pla == opp &&
        rootHistory.moveHistory[lastIdx-6].pla == opp &&
-       (rootSafeArea[moveLoc] == opp || rootSafeArea[moveLoc] == rootPla))
+       (rootSafeArea[moveLoc] == opp ||
+         (rootSafeArea[moveLoc] == rootPla && !rootBoard.isAdjacentToPla(moveLoc, opp))
+       ))
       return false;
   }
 


### PR DESCRIPTION
This allows analysis to rate/recommend these moves, even if one side is passing. It also means cleanup will usually (but not *always*) proceed through this path when playing via GTP, with the cleanup hack providing backup only.

This shouldn't unduly affect the length of training games, since the number of cleanup moves that can be played is strictly bounded, and most training games are terminated as soon as all territory is pass-alive anyway.