### PR TITLE
Fix batch normalization issue in Metal backend

### DIFF
--- a/cpp/neuralnet/metalbackend.cpp
+++ b/cpp/neuralnet/metalbackend.cpp
@@ -30,13 +30,8 @@ SWBatchNormLayerDesc MetalProcess::batchNormLayerDescToSwift(const BatchNormLaye
 
   SWBatchNormLayerDesc swDesc =
   createSWBatchNormLayerDesc(desc->numChannels,
-                             desc->epsilon,
-                             desc->hasScale,
-                             desc->hasBias,
-                             (float*)desc->mean.data(),
-                             (float*)desc->variance.data(),
-                             (float*)desc->scale.data(),
-                             (float*)desc->bias.data());
+                             (float*)desc->mergedScale.data(),
+                             (float*)desc->mergedBias.data());
 
   return swDesc;
 }
@@ -676,7 +671,7 @@ void MetalProcess::copyRowData(float* dest, const float* src, size_t numElements
 /**
  * @brief Convert input data from NHWC format to NCHW format in-place if necessary.
  *
- * @param data Pointer to the input data (single batch element assumed).
+ * @param rowSpatialInput Pointer to the input data (single batch element assumed).
  * @param C Number of channels.
  * @param H Height.
  * @param W Width.


### PR DESCRIPTION
- Updated the `batchNormLayerDescToSwift` function to utilize merged scale and bias pointers.
- Modified the `SWBatchNormLayerDesc` struct to remove individual mean, variance, scale, and bias pointers, replacing them with mergedScale and mergedBias.
- Adjusted the creation and handling of scale and bias data in the `BatchNormLayer` class for the merged scale and bias.

This commit has been verified by `./rungpuerrortest.sh`.
```
: batched current cfg error vs reference winrateError:         0.00002%  0.00004%  0.00008%  0.00014%
: batched current cfg error vs reference leadError:            0.00001   0.00001   0.00002   0.00003
: batched current cfg error vs reference scoreMeanError:       0.00001   0.00001   0.00002   0.00004
: batched current cfg error vs reference scoreStdevError:      0.00000   0.00001   0.00001   0.00002
: batched current cfg error vs reference topPolicyDelta:       0.00003%  0.00007%  0.00014%  0.00024%
: batched current cfg error vs reference policyKLDiv:          0.000000  0.000000  0.000000  0.000001
: batched current cfg error vs reference stWLErrorError:       0.00001c  0.00002c  0.00004c  0.00005c
: batched current cfg error vs reference stScErrorError:       0.00000   0.00000   0.00000   0.00001
: batched current cfg error vs reference ownershipError:       0.00002c  0.00006c  0.00016c  0.00129c
: GPU -1 finishing, processed 4494 rows 2997 batches
: GPU -1 finishing, processed 4494 rows 2997 batches
```