### PR TITLE
Fix build warnings and errors in Metal backend

### DIFF
--- a/cpp/neuralnet/metalbackend.cpp
+++ b/cpp/neuralnet/metalbackend.cpp
@@ -47,10 +47,12 @@ ActivationKind MetalProcess::activationLayerDescToSwift(const ActivationLayerDes
       return ActivationKind::mish();
     case ACTIVATION_MISH_SCALE8:
       testAssert(false); // Metal does not use scaled mish activations due to no fp16
+      return ActivationKind::identity(); // Placeholder for compilation
     case ACTIVATION_IDENTITY:
       return ActivationKind::identity();
     default:
       testAssert(false);
+      return ActivationKind::identity(); // Placeholder for compilation
   }
 }
 


### PR DESCRIPTION
This pull request addresses build warnings and errors encountered in both Ninja and Xcode when compiling the Metal backend code.

Ninja Warning: Resolved a warning indicating that a non-void function may not return a value in all control paths. Added a placeholder return for the ACTIVATION_MISH_SCALE8 and default cases.
Xcode Error: Fixed an error in Xcode related to the same issue by ensuring that the default case in the activationLayerDescToSwift function also returns a value.

No behavioral changes to the existing functionality, as the placeholders are intended only for compilation purposes.