### PR TITLE
Fix integer precision warnings in MetalProcess::processScoreValues

### DIFF
--- a/cpp/neuralnet/metalbackend.cpp
+++ b/cpp/neuralnet/metalbackend.cpp
@@ -856,7 +856,7 @@ void MetalProcess::processScoreValues(
   const float* currentScoreValueData = &inputBuffers->scoreValuesResults[offset];
 
   if(modelVersion >= 9) {
-    int numScoreValueChannels = inputBuffers->singleScoreValuesResultElts;
+    size_t numScoreValueChannels = inputBuffers->singleScoreValuesResultElts;
     assert(numScoreValueChannels == 6);
     currentOutput->whiteScoreMean = currentScoreValueData[0];
     currentOutput->whiteScoreMeanSq = currentScoreValueData[1];
@@ -866,7 +866,7 @@ void MetalProcess::processScoreValues(
     currentOutput->shorttermScoreError = currentScoreValueData[5];
   }
   else if(modelVersion >= 8) {
-    int numScoreValueChannels = inputBuffers->singleScoreValuesResultElts;
+    size_t numScoreValueChannels = inputBuffers->singleScoreValuesResultElts;
     assert(numScoreValueChannels == 4);
     currentOutput->whiteScoreMean = currentScoreValueData[0];
     currentOutput->whiteScoreMeanSq = currentScoreValueData[1];
@@ -876,7 +876,7 @@ void MetalProcess::processScoreValues(
     currentOutput->shorttermScoreError = 0;
   }
   else if(modelVersion >= 4) {
-    int numScoreValueChannels = inputBuffers->singleScoreValuesResultElts;
+    size_t numScoreValueChannels = inputBuffers->singleScoreValuesResultElts;
     assert(numScoreValueChannels == 2);
     currentOutput->whiteScoreMean = currentScoreValueData[0];
     currentOutput->whiteScoreMeanSq = currentScoreValueData[1];
@@ -887,7 +887,7 @@ void MetalProcess::processScoreValues(
   }
   else {
     assert(modelVersion >= 3);
-    int numScoreValueChannels = inputBuffers->singleScoreValuesResultElts;
+    size_t numScoreValueChannels = inputBuffers->singleScoreValuesResultElts;
     assert(numScoreValueChannels == 1);
     currentOutput->whiteScoreMean = currentScoreValueData[0];
     //Version 3 neural nets don't have any second moment currentOutput, implicitly already folding it in, so we just use the mean squared


### PR DESCRIPTION
This pull request addresses integer precision warnings in the MetalProcess::processScoreValues function within the metalbackend.cpp file. The local variable numScoreValueChannels has been updated from int to size_t to prevent implicit conversions and resolve compiler warnings.