### PR TITLE
Update cmake modules to resolve Metal backend build issue for cmake 4.*

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -111,14 +111,12 @@ elseif(USE_BACKEND STREQUAL "METAL")
   set(NEURALNET_BACKEND_SOURCES
     neuralnet/metalbackend.cpp
     )
-  _swift_generate_cxx_header_target(
-    KataGoSwift_Swift_h
+  add_library(KataGoSwift STATIC
+    neuralnet/metalbackend.swift)
+  _swift_generate_cxx_header(
     KataGoSwift
     "${CMAKE_CURRENT_BINARY_DIR}/include/KataGoSwift/KataGoSwift-swift.h"
     SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/neuralnet/metalbackend.swift")
-  add_library(KataGoSwift STATIC
-    neuralnet/metalbackend.swift)
-  add_dependencies(KataGoSwift KataGoSwift_Swift_h)
   target_include_directories(KataGoSwift PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/include")
   set_target_properties(KataGoSwift PROPERTIES Swift_MODULE_NAME "KataGoSwift")
   target_compile_options(KataGoSwift PUBLIC

--- a/cpp/external/macos/cmake/modules/AddSwift.cmake
+++ b/cpp/external/macos/cmake/modules/AddSwift.cmake
@@ -5,46 +5,74 @@
 #
 # See https://swift.org/LICENSE.txt for license information
 
-include(CheckCompilerFlag)
 
-# Generate bridging header from Swift to C++
-# NOTE: This logic will eventually be upstreamed into CMake
-function(_swift_generate_cxx_header_target target module header)
-  cmake_parse_arguments(ARG "" "" "SOURCES;SEARCH_PATHS;DEPENDS" ${ARGN})
-  if(NOT ARG_SOURCES)
-    message(FATAL_ERROR "No sources provided to 'swift_generate_cxx_header_target'")
+# Generate the bridging header from Swift to C++
+#
+# target: the name of the target to generate headers for.
+#         This target must build swift source files.
+# header: the name of the header file to generate.
+#
+# NOTE: This logic will eventually be unstreamed into CMake.
+function(_swift_generate_cxx_header target header)
+  if(NOT TARGET ${target})
+    message(FATAL_ERROR "Target ${target} not defined.")
+  endif()
+
+  if(NOT DEFINED CMAKE_Swift_COMPILER)
+    message(WARNING "Swift not enabled in project. Cannot generate headers for Swift files.")
+    return()
+  endif()
+
+  cmake_parse_arguments(ARG "" "" "SEARCH_PATHS;MODULE_NAME" ${ARGN})
+
+  if(NOT ARG_MODULE_NAME)
+    set(target_module_name $<TARGET_PROPERTY:${target},Swift_MODULE_NAME>)
+    set(ARG_MODULE_NAME $<IF:$<BOOL:${target_module_name}>,${target_module_name},${target}>)
   endif()
 
   if(ARG_SEARCH_PATHS)
     list(TRANSFORM ARG_SEARCH_PATHS PREPEND "-I")
-    string(REPLACE ";" " " EXPANDED_SEARCH_PATHS "${ARG_SEARCH_PATHS}")
   endif()
 
-  if(APPLE)
+  if(APPLE AND CMAKE_OSX_SYSROOT)
     set(SDK_FLAGS "-sdk" "${CMAKE_OSX_SYSROOT}")
   elseif(WIN32)
     set(SDK_FLAGS "-sdk" "$ENV{SDKROOT}")
+  elseif(CMAKE_SYSROOT)
+    set(SDK_FLAGS "-sdk" "${CMAKE_SYSROOT}")
   endif()
 
-  add_custom_command(
-    OUTPUT
-      "${header}"
-    COMMAND
-      ${CMAKE_Swift_COMPILER} -frontend -typecheck
-      ${EXPANDED_SEARCH_PATHS}
-      ${ARG_SOURCES}
-      ${SDK_FLAGS}
-      -module-name "${module}"
-      -cxx-interoperability-mode=default
-      -emit-clang-header-path "${header}"
-    DEPENDS
-      ${ARG_DEPENDS}
-    COMMENT
-      "Generating '${header}'"
-  )
+  cmake_path(APPEND CMAKE_CURRENT_BINARY_DIR include
+    OUTPUT_VARIABLE base_path)
 
-  add_custom_target("${target}"
-    DEPENDS
-      "${header}"
-  )
+  cmake_path(APPEND base_path ${header}
+    OUTPUT_VARIABLE header_path)
+
+  cmake_path(APPEND CMAKE_CURRENT_BINARY_DIR "${ARG_MODULE_NAME}.emit-module.d" OUTPUT_VARIABLE depfile_path)
+
+  set(_AllSources $<PATH:ABSOLUTE_PATH,$<TARGET_PROPERTY:${target},SOURCES>,${CMAKE_CURRENT_SOURCE_DIR}>)
+  set(_SwiftSources $<FILTER:${_AllSources},INCLUDE,\\.swift$>)
+  add_custom_command(OUTPUT ${header_path}
+    DEPENDS ${_SwiftSources}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMAND
+      ${CMAKE_Swift_COMPILER} -typecheck
+      ${ARG_SEARCH_PATHS}
+      ${_SwiftSources}
+      ${SDK_FLAGS}
+      -module-name "${ARG_MODULE_NAME}"
+      -cxx-interoperability-mode=default
+      -emit-clang-header-path ${header_path}
+      -emit-dependencies
+    DEPFILE "${depfile_path}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    COMMENT
+      "Generating '${header_path}'"
+    COMMAND_EXPAND_LISTS)
+
+  # Added to public interface for dependees to find.
+  target_include_directories(${target} PUBLIC ${base_path})
+  # Added to the target to ensure target rebuilds if header changes and is used
+  # by sources in the target.
+  target_sources(${target} PRIVATE ${header_path})
 endfunction()

--- a/cpp/external/macos/cmake/modules/InitializeSwift.cmake
+++ b/cpp/external/macos/cmake/modules/InitializeSwift.cmake
@@ -26,7 +26,7 @@ endfunction()
 function(_setup_swift_paths)
   # If we haven't set the swift library search paths, do that now
   if(NOT SWIFT_LIBRARY_SEARCH_PATHS)
-    if(APPLE)
+    if(CMAKE_OSX_SYSROOT)
       set(SDK_FLAGS "-sdk" "${CMAKE_OSX_SYSROOT}")
     endif()
 


### PR DESCRIPTION
### Summary

This pull request updates the `cmake` modules to align with the latest implementation from [swift-cmake-examples](https://github.com/swiftlang/swift-cmake-examples).
The update resolves https://github.com/lightvector/KataGo/issues/1063, allowing the Metal backend to be successfully built using `cmake 4.*`.

### Background

The same modification was first introduced and tested in the https://github.com/ChinChangYang/KataGo/pull/6.
A GitHub Action workflow has already verified this approach on `macos-13` with `cmake 4.*` in https://github.com/ChinChangYang/KataGo/commit/3cb0e052683e9d81dd25e184819d6fbf894fee1f.

### Notes

* Aligns `cmake` modules with upstream Swift examples.
* Confirms compatibility with `cmake 4.*` and the Metal backend build process.
* Builds successfully verified via CI on macOS.