### PR TITLE
Fix potential division by zero in cpuctUtilityStdevPrior

### DIFF
--- a/cpp/program/setup.cpp
+++ b/cpp/program/setup.cpp
@@ -489,8 +489,8 @@ vector<SearchParams> Setup::loadParams(
     else if(cfg.contains("cpuctExplorationBase"))   params.cpuctExplorationBase = cfg.getDouble("cpuctExplorationBase",        10.0, 100000.0);
     else                                            params.cpuctExplorationBase = 500.0;
 
-    if(cfg.contains("cpuctUtilityStdevPrior"+idxStr)) params.cpuctUtilityStdevPrior = cfg.getDouble("cpuctUtilityStdevPrior"+idxStr, 0.0, 10.0);
-    else if(cfg.contains("cpuctUtilityStdevPrior"))   params.cpuctUtilityStdevPrior = cfg.getDouble("cpuctUtilityStdevPrior",        0.0, 10.0);
+    if(cfg.contains("cpuctUtilityStdevPrior"+idxStr)) params.cpuctUtilityStdevPrior = cfg.getDouble("cpuctUtilityStdevPrior"+idxStr, 1e-20, 10.0);
+    else if(cfg.contains("cpuctUtilityStdevPrior"))   params.cpuctUtilityStdevPrior = cfg.getDouble("cpuctUtilityStdevPrior",        1e-20, 10.0);
     else                                              params.cpuctUtilityStdevPrior = 0.40;
     if(cfg.contains("cpuctUtilityStdevPriorWeight"+idxStr)) params.cpuctUtilityStdevPriorWeight = cfg.getDouble("cpuctUtilityStdevPriorWeight"+idxStr, 0.0, 100.0);
     else if(cfg.contains("cpuctUtilityStdevPriorWeight"))   params.cpuctUtilityStdevPriorWeight = cfg.getDouble("cpuctUtilityStdevPriorWeight",        0.0, 100.0);


### PR DESCRIPTION
## Summary

- Fix potential division by zero in `searchexplorehelpers.cpp` by rejecting zero values for `cpuctUtilityStdevPrior` at parameter validation time
- Change minimum allowed value from `0.0` to `1e-20` in `setup.cpp`

Fixes #831

## Test plan

- [x] Verified `cpuctUtilityStdevPrior = 0.0` is rejected with error message
- [x] Verified `cpuctUtilityStdevPrior = 1e-20` is accepted (minimum boundary)
- [x] Verified `cpuctUtilityStdevPrior = 10.0` is accepted (maximum boundary)
- [x] Verified `cpuctUtilityStdevPrior = 10.1` is rejected with error message

🤖 Generated with [Claude Code](https://claude.ai/code)