### PR TITLE
Make `Board` references constant where possible to improve clarity and avoid unnecessary copies

### DIFF
--- a/cpp/book/book.cpp
+++ b/cpp/book/book.cpp
@@ -2758,7 +2758,7 @@ int64_t Book::exportToHtmlDir(
     if(hist.encorePhase > 0)
       return;
 
-    Board board = hist.getRecentBoard(0);
+    const Board& board = hist.getRecentBoard(0);
 
     if(contains(rulesLabel,'"') || contains(rulesLabel,'\n'))
       throw StringError("rulesLabel cannot contain quotes or newlines");

--- a/cpp/command/gatekeeper.cpp
+++ b/cpp/command/gatekeeper.cpp
@@ -140,7 +140,7 @@ namespace {
         }
         else {
           BoardHistory hist(data->endHist);
-          Board endBoard = hist.getRecentBoard(0);
+          const Board& endBoard = hist.getRecentBoard(0);
           //Force game end just in caseif we crossed a move limit
           if(!hist.isGameFinished)
             hist.endAndScoreGameNow(endBoard);

--- a/cpp/command/genbook.cpp
+++ b/cpp/command/genbook.cpp
@@ -648,7 +648,7 @@ int MainCmds::genbook(const vector<string>& args) {
     avoidMoveUntilByLoc = std::vector<int>(Board::MAX_ARR_SIZE,0);
     isReExpansion = allowReExpansion && constNode.canReExpand() && constNode.recursiveValues().visits <= book->getParams().maxVisitsForReExpansion;
     Player pla = hist.presumedNextMovePla;
-    Board board = hist.getRecentBoard(0);
+    const Board& board = hist.getRecentBoard(0);
     bool hasAtLeastOneLegalNewMove = false;
     for(Loc moveLoc = 0; moveLoc < Board::MAX_ARR_SIZE; moveLoc++) {
       if(hist.isLegal(board,moveLoc,pla)) {
@@ -819,7 +819,7 @@ int MainCmds::genbook(const vector<string>& args) {
     }
 
     Player pla = hist.presumedNextMovePla;
-    Board board = hist.getRecentBoard(0);
+    const Board& board = hist.getRecentBoard(0);
     search->setPosition(pla,board,hist);
     search->setRootSymmetryPruningOnly(symmetries);
 
@@ -1186,7 +1186,7 @@ int MainCmds::genbook(const vector<string>& args) {
       BookHash::getHashAndSymmetry(hist, book->repBound, hashRet, symmetryToAlignRet, symmetriesRet, book->bookVersion);
       if(hashRet != node.hash()) {
         ostringstream out;
-        Board board = hist.getRecentBoard(0);
+        const Board& board = hist.getRecentBoard(0);
         Board::printBoard(out, board, Board::NULL_LOC, NULL);
         for(Loc move: moveHistory)
           out << Location::toString(move,book->initialBoard) << " ";
@@ -1207,7 +1207,7 @@ int MainCmds::genbook(const vector<string>& args) {
 
     Search* search = searches[gameThreadIdx];
     Player pla = hist.presumedNextMovePla;
-    Board board = hist.getRecentBoard(0);
+    const Board& board = hist.getRecentBoard(0);
     search->setPosition(pla,board,hist);
     search->setRootSymmetryPruningOnly(symmetries);
 
@@ -1712,7 +1712,7 @@ int MainCmds::checkbook(const vector<string>& args) {
       logger.write("or else some hash collision or something else is wrong.");
       logger.write("BookHash of node unable to expand: " + constNode.hash().toString());
       ostringstream out;
-      Board board = hist.getRecentBoard(0);
+      const Board& board = hist.getRecentBoard(0);
       Board::printBoard(out, board, Board::NULL_LOC, NULL);
       for(Loc move: moveHistory)
         out << Location::toString(move,book->initialBoard) << " ";
@@ -1729,7 +1729,7 @@ int MainCmds::checkbook(const vector<string>& args) {
       if(hashRet != node.hash()) {
         logger.write("Book failed integrity check, the node with hash " + node.hash().toString() + " when walked to has hash " + hashRet.toString());
         ostringstream out;
-        Board board = hist.getRecentBoard(0);
+        const Board& board = hist.getRecentBoard(0);
         Board::printBoard(out, board, Board::NULL_LOC, NULL);
         for(Loc move: moveHistory)
           out << Location::toString(move,book->initialBoard) << " ";
@@ -1948,7 +1948,7 @@ int MainCmds::booktoposes(const vector<string>& args) {
         logger.write("BookHash of node unable to expand: " + node.hash().toString());
 
         ostringstream out;
-        Board board = hist.getRecentBoard(0);
+        const Board& board = hist.getRecentBoard(0);
         Board::printBoard(out, board, Board::NULL_LOC, NULL);
         for(Loc move: moveHistory)
           out << Location::toString(move,book->initialBoard) << " ";
@@ -1997,7 +1997,7 @@ int MainCmds::booktoposes(const vector<string>& args) {
       double policySurprise = 0.0;
       double valueSurpriseIrreducible = 0.0;
       double valueSurpriseTotal = 0.0;
-      Board board = hist.getRecentBoard(0);
+      const Board& board = hist.getRecentBoard(0);
       for(int sym = 0; sym<SymmetryHelpers::NUM_SYMMETRIES; sym++) {
         MiscNNInputParams nnInputParams;
         nnInputParams.symmetry = sym;
@@ -2545,7 +2545,7 @@ int MainCmds::findbookbottlenecks(const vector<string>& args) {
           out << Location::toString(move, book->initialBoard) << " ";
         out << "\n";
 
-        Board board = hist.getRecentBoard(0);
+        const Board& board = hist.getRecentBoard(0);
         Board::printBoard(out, board, Board::NULL_LOC, &(hist.moveHistory));
 
         out << ("Num nodes to change: " + Global::intToString((int)result.nodes.size())) << endl;

--- a/cpp/command/startposes.cpp
+++ b/cpp/command/startposes.cpp
@@ -2416,7 +2416,7 @@ int MainCmds::checksgfhintpolicy(const vector<string>& args) {
           BoardHistory histBefore;
           bool suc = priorPosSample.tryGetCurrentBoardHistory(rules,nextPla,histBefore);
           testAssert(suc);
-          Board board = histBefore.getRecentBoard(0);
+          const Board& board = histBefore.getRecentBoard(0);
 
           for(int symmetry = 0; symmetry < 8; symmetry++) {
             MiscNNInputParams nnInputParams;

--- a/cpp/neuralnet/nneval.cpp
+++ b/cpp/neuralnet/nneval.cpp
@@ -669,7 +669,7 @@ static bool daggerMatch(const Board& board, Player nextPla, Loc& banned, int sym
 }
 
 std::shared_ptr<NNOutput>* NNEvaluator::averageMultipleSymmetries(
-  Board& board,
+  const Board& board,
   const BoardHistory& history,
   Player nextPlayer,
   const SGFMetadata* sgfMeta,
@@ -698,7 +698,7 @@ std::shared_ptr<NNOutput>* NNEvaluator::averageMultipleSymmetries(
 }
 
 void NNEvaluator::evaluate(
-  Board& board,
+  const Board& board,
   const BoardHistory& history,
   Player nextPlayer,
   const MiscNNInputParams& nnInputParams,
@@ -719,7 +719,7 @@ void NNEvaluator::evaluate(
 }
 
 void NNEvaluator::evaluate(
-  Board& board,
+  const Board& board,
   const BoardHistory& history,
   Player nextPlayer,
   const SGFMetadata* sgfMeta,

--- a/cpp/neuralnet/nneval.h
+++ b/cpp/neuralnet/nneval.h
@@ -143,7 +143,7 @@ class NNEvaluator {
   //logStream is for some error logging, can be NULL.
   //This function is threadsafe.
   void evaluate(
-    Board& board,
+    const Board& board,
     const BoardHistory& history,
     Player nextPlayer,
     const MiscNNInputParams& nnInputParams,
@@ -152,7 +152,7 @@ class NNEvaluator {
     bool includeOwnerMap
   );
   void evaluate(
-    Board& board,
+    const Board& board,
     const BoardHistory& history,
     Player nextPlayer,
     const SGFMetadata* sgfMeta,
@@ -162,7 +162,7 @@ class NNEvaluator {
     bool includeOwnerMap
   );
   std::shared_ptr<NNOutput>* averageMultipleSymmetries(
-    Board& board,
+    const Board& board,
     const BoardHistory& history,
     Player nextPlayer,
     const SGFMetadata* sgfMeta,

--- a/cpp/program/play.cpp
+++ b/cpp/program/play.cpp
@@ -751,7 +751,7 @@ pair<int,int> MatchPairer::getMatchupPairUnsynchronized() {
 
 //----------------------------------------------------------------------------------------------------------
 
-static void failIllegalMove(Search* bot, Logger& logger, Board board, Loc loc) {
+static void failIllegalMove(Search* bot, Logger& logger, const Board& board, Loc loc) {
   ostringstream sout;
   sout << "Bot returned null location or illegal move!?!" << "\n";
   sout << board << "\n";
@@ -887,8 +887,7 @@ static NNRawStats computeNNRawStats(const Search* bot, const Board& board, const
   NNResultBuf buf;
   MiscNNInputParams nnInputParams;
   nnInputParams.drawEquivalentWinsForWhite = bot->searchParams.drawEquivalentWinsForWhite;
-  Board b = board;
-  bot->nnEvaluator->evaluate(b,hist,pla,nnInputParams,buf,false,false);
+  bot->nnEvaluator->evaluate(board,hist,pla,nnInputParams,buf,false,false);
   NNOutput& nnOutput = *(buf.result);
 
   NNRawStats nnRawStats;

--- a/cpp/program/playutils.cpp
+++ b/cpp/program/playutils.cpp
@@ -1244,13 +1244,12 @@ std::shared_ptr<NNOutput> PlayUtils::getFullSymmetryNNOutput(
   const Board& board, const BoardHistory& hist, Player pla, bool includeOwnerMap, const SGFMetadata* sgfMeta, NNEvaluator* nnEval
 ) {
   vector<std::shared_ptr<NNOutput>> ptrs;
-  Board b = board;
   for(int sym = 0; sym<SymmetryHelpers::NUM_SYMMETRIES; sym++) {
     MiscNNInputParams nnInputParams;
     nnInputParams.symmetry = sym;
     NNResultBuf buf;
     bool skipCache = true; //Always ignore cache so that we use the desired symmetry
-    nnEval->evaluate(b,hist,pla,sgfMeta,nnInputParams,buf,skipCache,includeOwnerMap);
+    nnEval->evaluate(board,hist,pla,sgfMeta,nnInputParams,buf,skipCache,includeOwnerMap);
     ptrs.push_back(std::move(buf.result));
   }
   std::shared_ptr<NNOutput> result(new NNOutput(ptrs));

--- a/cpp/tests/testnnevalcanary.cpp
+++ b/cpp/tests/testnnevalcanary.cpp
@@ -577,7 +577,7 @@ bool Tests::runBackendErrorTest(
     throw StringError("Unknown dataset to test gpu error on: " + boardSizeDataset);
 
   auto evalBoard = [&](NNEvaluator* nnE, const BoardHistory& hist) {
-    Board board = hist.getRecentBoard(0);
+    const Board& board = hist.getRecentBoard(0);
     MiscNNInputParams nnInputParams;
     nnInputParams.symmetry = (int)(BoardHistory::getSituationRulesAndKoHash(board,hist,hist.presumedNextMovePla,0.5).hash0 & 7);
     nnInputParams.policyOptimism = policyOptimismForTest;


### PR DESCRIPTION
It looks like `NNEvaluator::evaluate` is a hot path and it would be nice to get rid of redundant copies. And it looks consistent because `BoardHistory` is also passed by const reference to `evaluate`.