### PR TITLE
Configure clang-tidy static analysis in CMake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y cmake build-essential zlib1g-dev libzip-dev opencl-headers ocl-icd-opencl-dev
+        sudo apt-get install -y cmake build-essential zlib1g-dev libzip-dev opencl-headers ocl-icd-opencl-dev clang-tidy
 
     - name: Cache CMake build
       uses: actions/cache@v4
@@ -35,7 +35,7 @@ jobs:
     - name: Configure CMake
       working-directory: cpp
       run: |
-        cmake . -DUSE_BACKEND=OPENCL -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS_RELEASE="-s"
+        cmake . -DUSE_BACKEND=OPENCL -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS_RELEASE="-s" -DUSE_CLANG_TIDY=1
 
     - name: Build
       working-directory: cpp
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install zlib libzip opencl-headers
+          brew install zlib libzip opencl-headers llvm
       - name: Cache CMake build
         uses: actions/cache@v4
         with:
@@ -81,7 +81,7 @@ jobs:
       - name: Configure CMake
         working-directory: cpp
         run: |
-          cmake . -G Ninja -DUSE_BACKEND=OPENCL -DCMAKE_BUILD_TYPE=Release
+          cmake . -G Ninja -DUSE_BACKEND=OPENCL -DCMAKE_BUILD_TYPE=Release -DUSE_CLANG_TIDY=1
       - name: Build
         working-directory: cpp
         run: |
@@ -128,7 +128,8 @@ jobs:
       run: |
         cmake . -G "Visual Studio 17 2022" -A x64 `
           -DUSE_BACKEND=OPENCL `
-          -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+          -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
+          -DUSE_CLANG_TIDY=0
 
     - name: Build
       working-directory: cpp

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -50,6 +50,8 @@ set(USE_BIGGER_BOARDS_EXPENSIVE 0 CACHE BOOL "Allow boards up to size 50. Compil
 set(USE_CACHE_TENSORRT_PLAN 0 CACHE BOOL "Use TENSORRT plan cache. May use a lot of disk space. Only applies when USE_BACKEND is TENSORRT.")
 mark_as_advanced(USE_CACHE_TENSORRT_PLAN)
 
+set(USE_CLANG_TIDY 1 CACHE BOOL "Run clang-tidy static analysis during build")
+
 #--------------------------- NEURAL NET BACKEND ------------------------------------------------------------------------
 
 message(STATUS "Building 'katago' executable for GTP engine and other tools.")
@@ -608,6 +610,13 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "C
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free")
   endif()
 
+endif()
+
+if(USE_CLANG_TIDY)
+  message(STATUS "Setting up clang-tidy checks.")
+  find_program(CLANG_TIDY_EXE NAMES clang-tidy HINTS /opt/homebrew/opt/llvm/bin REQUIRED)
+  set_target_properties(katago PROPERTIES
+    CXX_CLANG_TIDY "${CLANG_TIDY_EXE};-checks=-*,performance-inefficient-vector-operation,performance-unnecessary-copy-initialization,readability-non-const-parameter,readability-make-member-function-const")
 endif()
 
 target_include_directories(katago PUBLIC ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
Enable already applied checks (from #1167)