### PR TITLE
fix: set optimizer_name in train_state when loading checkpoint without optimizer

### DIFF
--- a/python/train.py
+++ b/python/train.py
@@ -774,6 +774,7 @@ def main(rank: int, world_size: int, args, multi_gpu_device_ids, readpipes, writ
 
             else:
                 logging.info("WARNING: Optimizer not found in state dict, using fresh optimizer")
+                train_state["optimizer_name"] = optimizer_name
 
             return (model_config, ddp_model, raw_model, swa_model, optimizer, metrics_obj, running_metrics, train_state, last_val_metrics)
 


### PR DESCRIPTION
fix: set optimizer_name in train_state when loading checkpoint without optimizer