### PR TITLE
CI: key macOS-metal CMake cache on Homebrew dependency versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,6 +110,18 @@ jobs:
         run: |
           brew install ninja zlib libzip protobuf abseil
 
+      # The cached CMakeCache.txt/build.ninja bake in version-pinned Homebrew
+      # Cellar paths (e.g. -L/opt/homebrew/Cellar/protobuf/<ver>/lib) that
+      # pkg-config emits at configure time. When Homebrew bumps protobuf/abseil,
+      # those paths vanish and an incremental `cmake .` does NOT refresh the
+      # cached pkg-config vars, so the re-link fails with "library 'protobuf'
+      # not found". Key the cache on the installed dep versions so a bump
+      # invalidates the stale configure instead of resurrecting dead paths.
+      - name: Resolve dependency versions for cache key
+        id: depvers
+        run: |
+          echo "vers=$(brew list --versions protobuf abseil | tr ' ' '-' | paste -sd '_' -)" >> "$GITHUB_OUTPUT"
+
       - name: Cache CMake build
         uses: actions/cache@v4
         with:
@@ -119,9 +131,11 @@ jobs:
             cpp/build.ninja
             cpp/.ninja_deps
             cpp/.ninja_log
-          key: ${{ runner.os }}-cmake-metal-${{ hashFiles('**/CMakeLists.txt') }}
+          key: ${{ runner.os }}-cmake-metal-${{ steps.depvers.outputs.vers }}-${{ hashFiles('**/CMakeLists.txt') }}
+          # Scoped to the same dep versions: never restore a cache built against
+          # a different protobuf/abseil (its baked-in Cellar paths would be stale).
           restore-keys: |
-            ${{ runner.os }}-cmake-metal-
+            ${{ runner.os }}-cmake-metal-${{ steps.depvers.outputs.vers }}-
 
       - name: Configure CMake
         working-directory: cpp


### PR DESCRIPTION
## Summary

Split out from #1202 as a standalone, orthogonal CI fix.

The `build-macos-metal` job caches `CMakeCache.txt`/`build.ninja` keyed only on `CMakeLists.txt` hashes. Those cached files bake in version-pinned Homebrew Cellar paths emitted by pkg-config at configure time (e.g. `-L/opt/homebrew/Cellar/protobuf/<ver>/lib`). When Homebrew bumps `protobuf`/`abseil`, those paths vanish, and an incremental `cmake .` does **not** refresh the cached pkg-config vars — so the re-link fails with `ld: library 'protobuf' not found`.

## Fix

- Resolve the installed `protobuf`/`abseil` versions into a `depvers` step output.
- Include those versions in the cache key and scope `restore-keys` to them, so a dependency bump invalidates the stale configure and forces a fresh pkg-config resolution instead of resurrecting dead Cellar paths.

Touches only `.github/workflows/build.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)