### PR TITLE
Default TensorRT transformer trunks to NHWC

### DIFF
--- a/cpp/configs/gtp_example.cfg
+++ b/cpp/configs/gtp_example.cfg
@@ -410,6 +410,10 @@ searchFactorWhenWinningThreshold = 0.95
 # ------------------------------
 # These only apply when using the TENSORRT version of KataGo.
 
+# Transformer trunks use NHWC by default. Set this to false only after benchmarking
+# the particular GPU and TensorRT version.
+# trtTransformerNHWC = true
+
 # For one GPU: optionally uncomment this option and change if the GPU to
 # use is not device 0.
 # trtDeviceToUse = 0

--- a/cpp/neuralnet/onnxmodelbuilder.cpp
+++ b/cpp/neuralnet/onnxmodelbuilder.cpp
@@ -15,8 +15,8 @@ using namespace std;
 namespace {
 
 // Builder that accumulates ONNX nodes and initializers into a single GraphProto, handing back
-// tensor names as it goes. Tensors are float32; the trunk runs NCHW by
-// default, or channel-last NHWC when transformerNHWC is set (see buildBlockStack / buildConv).
+// tensor names as it goes. Tensors are float32; transformerNHWC selects a channel-last NHWC trunk
+// instead of NCHW (see buildBlockStack / buildConv).
 struct Builder {
   onnx::GraphProto* graph;
   int nnXLen;

--- a/cpp/neuralnet/trtbackend.cpp
+++ b/cpp/neuralnet/trtbackend.cpp
@@ -94,7 +94,6 @@ ComputeContext* NeuralNet::createComputeContext(
   ConfigParser& cfg) {
   (void)gpuIdxs;
   (void)logger;
-  (void)loadedModel;
 
   ComputeContext* context = new ComputeContext();
   context->nnXLen = nnXLen;
@@ -105,11 +104,12 @@ ComputeContext* NeuralNet::createComputeContext(
   // nvonnxparser (the default). trtDisableOnnx=true falls back to the hand-built ModelParser, which
   // supports convnets only (transformer models will error in createComputeHandle).
   context->useOnnx = !(cfg.contains("trtDisableOnnx") ? cfg.getBool("trtDisableOnnx") : false);
-  // ONNX transformer emitter layout. Default is NCHW (genuine channel-major attention/FFN): benchmarks
-  // show it matches or slightly beats the NHWC bubble path at the saturated throughput operating point
-  // KataGo runs at, and it's the simpler graph. trtTransformerNHWC=true opts into the NHWC path (whole
-  // trunk channel-last with NCHW<->NHWC conversions around it), which wins on single-stream latency.
-  context->transformerNHWC = cfg.contains("trtTransformerNHWC") ? cfg.getBool("trtTransformerNHWC") : false;
+  // Transformer trunks default to NHWC, which benchmarks at least as fast as NCHW across tested GPUs
+  // and TensorRT versions. Explicit false remains available for hardware-specific tuning. Normalize
+  // convnets to false since the ONNX builder ignores this setting for models without transformers.
+  context->transformerNHWC =
+    (cfg.contains("trtTransformerNHWC") ? cfg.getBool("trtTransformerNHWC") : true) &&
+    NeuralNet::getModelDesc(loadedModel).hasAnyTransformerBlocks();
   // Debugging: if set, the ONNX-emitter path dumps the emitted ONNX model and the built engine's
   // per-layer info (precision/format/tactic, via a detailed-profiling build + IEngineInspector) into
   // this directory. Files are disambiguated by board size, FP16/FP32, and exact/max NN-length so the


### PR DESCRIPTION
## Summary

- Default TensorRT transformer trunks to NHWC.
- Keep `trtTransformerNHWC=false` as an explicit per-machine fallback.
- Normalize non-transformer models to NCHW so convnets do not create redundant plan/timing cache entries.
- Document the default and override in `gtp_example.cfg`.

## Motivation

The old NCHW default was based on earlier TensorRT results. Current results point the other way: my RTX PRO 6000 Blackwell test with TensorRT 10.16.1 showed a large NHWC win, and follow-up testing by lightvector on a weak laptop GPU and an A5000 found NHWC equal or faster on both TensorRT 10.9 and 10.16.

Official `katago benchmark` results for [`b11c768h12nbt3tflrs-fson-silu`](https://huggingface.co/TomGrc/weight/resolve/main/b11c768h12nbt3tflrs-fson-silu.bin.gz), FP16, fixed symmetry and seed:

| Backend/layout | Recommended threads | visits/s | nnEvals/s |
|---|---:|---:|---:|
| CUDA | 64 | 2814.27 | 2716.93 |
| TensorRT NCHW | 40 | 1625.87 | 1531.59 |
| TensorRT NHWC | 32 | 2836.89 | 2612.18 |

Equal-thread NHWC gains over NCHW were +29.1% at 5 threads, +55.8% at 16, +81.2% at 32, and +78.6% at 64.

The resolved layout is already part of the timing-cache hash and the `onnx` / `onnxnh` plan-cache tag, so the two engine layouts cannot collide.

## Validation

- Fresh TensorRT build at this PR's exact commit against TensorRT 10.16.1 / CUDA 13.
- With no `trtTransformerNHWC` key, runtime logged `transformerNHWC=true`: 2852.22 visits/s, 2622.04 nnEvals/s at 32 threads.
- With explicit `trtTransformerNHWC=false`, runtime logged `transformerNHWC=false`: 1578.90 visits/s, 1453.44 nnEvals/s at 32 threads.
- OpenCL full build, `katago runtests`, and `katago runoutputtests`.