### PR TITLE
Optimize TensorRT CUDA Graph/concurrency and add benchmark auto-tuning

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -471,7 +471,7 @@ elseif(USE_BACKEND STREQUAL "TENSORRT")
   if(NOT TENSORRT_ONNXPARSER_LIBRARY)
     message(FATAL_ERROR "${ColorBoldRed} libnvonnxparser was NOT found in the TensorRT lib dir. ${ColorReset}")
   endif()
-  target_link_libraries(katago ${TENSORRT_ONNXPARSER_LIBRARY} ${Protobuf_LIBRARIES})
+  target_link_libraries(katago ${TENSORRT_ONNXPARSER_LIBRARY} protobuf::libprotobuf)
 elseif(USE_BACKEND STREQUAL "METAL")
   target_compile_definitions(katago PRIVATE USE_METAL_BACKEND)
   target_link_libraries(katago KataGoSwift katagocoreml

--- a/cpp/command/benchmark.cpp
+++ b/cpp/command/benchmark.cpp
@@ -18,7 +18,20 @@
 
 using namespace std;
 
-static NNEvaluator* createNNEval(int maxNumThreads, const CompactSgf& sgf, const string& modelFile, Logger& logger, ConfigParser& cfg, const SearchParams& params);
+struct BatchSizeBenchmarkResult {
+  int maxBatchSize;
+  PlayUtils::BenchmarkResults benchmarkResult;
+};
+
+static NNEvaluator* createNNEval(
+  int requestedMaxBatchSize,
+  bool useExactMaxBatchSize,
+  const CompactSgf& sgf,
+  const string& modelFile,
+  Logger& logger,
+  ConfigParser& cfg,
+  const SearchParams& params
+);
 
 static vector<PlayUtils::BenchmarkResults> doFixedTuneThreads(
   const SearchParams& params,
@@ -41,6 +54,17 @@ static vector<PlayUtils::BenchmarkResults> doAutoTuneThreads(
   const std::function<void(int)>& reallocateNNEvalWithEnoughBatchSize,
   const std::function<int(int)>& getDesiredBatchSize
 );
+static vector<BatchSizeBenchmarkResult> doFixedTuneBatchSizes(
+  const SearchParams& params,
+  const CompactSgf& sgf,
+  int numPositionsPerGame,
+  NNEvaluator*& nnEval,
+  Logger& logger,
+  double secondsPerGameMove,
+  const vector<int>& maxBatchSizesToTest,
+  const vector<int>& numThreadsToTest,
+  const std::function<void(int)>& reallocateNNEvalForExactBatchSize
+);
 
 #ifdef USE_EIGEN_BACKEND
 static const int64_t defaultMaxVisits = 80;
@@ -61,6 +85,7 @@ int MainCmds::benchmark(const vector<string>& args) {
   int boardSize;
   int64_t maxVisits;
   vector<int> numThreadsToTest;
+  vector<int> maxBatchSizesToTest;
   int numPositionsPerGame;
   bool autoTuneThreads;
   int fixedBatchSize;
@@ -84,6 +109,11 @@ int MainCmds::benchmark(const vector<string>& args) {
     );
     TCLAP::SwitchArg autoTuneThreadsArg("s","tune","Automatically search for the optimal number of threads (default if not specifying specific numbers of threads)");
     TCLAP::ValueArg<int> fixedBatchSizeArg("","fixed-batch-size","Set max batch size to this fixed value",false,-1,"NUM");
+    TCLAP::ValueArg<string> maxBatchSizesArg(
+      "","max-batch-sizes",
+      "Test the Cartesian product of these exact max batch sizes and explicitly specified -threads, comma-separated (cannot use -tune)",
+      false,"","BATCHES"
+    );
     TCLAP::SwitchArg halfBatchSizeArg("","half-batch-size","Set max batch size to half of the number of threads");
     TCLAP::ValueArg<double> secondsPerGameMoveArg(
       "i","time",
@@ -103,6 +133,7 @@ int MainCmds::benchmark(const vector<string>& args) {
     cmd.add(boardSizeArg);
     cmd.add(autoTuneThreadsArg);
     cmd.add(fixedBatchSizeArg);
+    cmd.add(maxBatchSizesArg);
     cmd.add(halfBatchSizeArg);
     cmd.add(secondsPerGameMoveArg);
     cmd.parseArgs(args);
@@ -115,6 +146,8 @@ int MainCmds::benchmark(const vector<string>& args) {
     numPositionsPerGame = numPositionsPerGameArg.getValue();
     autoTuneThreads = autoTuneThreadsArg.getValue();
     fixedBatchSize = fixedBatchSizeArg.getValue();
+    string maxBatchSizesStr = maxBatchSizesArg.getValue();
+    const bool maxBatchSizesSpecified = maxBatchSizesArg.isSet();
     useHalfBatchSize = halfBatchSizeArg.getValue();
     secondsPerGameMove = secondsPerGameMoveArg.getValue();
 
@@ -128,12 +161,23 @@ int MainCmds::benchmark(const vector<string>& args) {
       throw StringError("Number of positions per game to use: invalid value " + Global::intToString(numPositionsPerGame));
     if(secondsPerGameMove <= 0 || secondsPerGameMove > 1000000)
       throw StringError("Number of seconds per game move to assume: invalid value " + Global::doubleToString(secondsPerGameMove));
+    if(maxBatchSizesSpecified && autoTuneThreads)
+      throw StringError("Cannot combine max batch size tuning with automatic thread tuning");
     if(desiredThreadsStr != "" && autoTuneThreads)
       throw StringError("Cannot both automatically tune threads and specify fixed exact numbers of threads to test");
     if(fixedBatchSize != -1 && (fixedBatchSize <= 0 || fixedBatchSize > 65536))
       throw StringError("Invalid value for fixed batch size");
     if(fixedBatchSize != -1 && useHalfBatchSize)
       throw StringError("Cannot specify both fixed batch size and use half batch size");
+    if(maxBatchSizesSpecified && (fixedBatchSize != -1 || useHalfBatchSize))
+      throw StringError("Cannot combine max batch size tuning with fixed batch size or half batch size");
+    if(maxBatchSizesSpecified && desiredThreadsStr == "")
+      throw StringError("Max batch size tuning requires an explicit list of thread counts using -threads");
+
+    if(maxBatchSizesSpecified)
+      maxBatchSizesToTest = KataGoCommandLine::parseCommaSeparatedUniqueInts(
+        maxBatchSizesStr,1,65536,"Max batch size to test"
+      );
 
     //Apply default
     if(desiredThreadsStr == "")
@@ -193,8 +237,16 @@ int MainCmds::benchmark(const vector<string>& args) {
 
   Setup::initializeSession(cfg);
 
+  const bool tuneMaxBatchSize = maxBatchSizesToTest.size() > 0;
+#ifdef USE_EIGEN_BACKEND
+  if(tuneMaxBatchSize)
+    throw StringError("Max batch size tuning is not supported by the Eigen backend");
+#endif
+
   if(cfg.contains("nnMaxBatchSize")) {
-    if(fixedBatchSize != -1)
+    if(tuneMaxBatchSize)
+      cout << "WARNING: Your nnMaxBatchSize is hardcoded to " + cfg.getString("nnMaxBatchSize") + ", ignoring it while tuning max batch size for this benchmark." << endl;
+    else if(fixedBatchSize != -1)
       cout << "WARNING: Your nnMaxBatchSize is hardcoded to " + cfg.getString("nnMaxBatchSize") + ", ignoring it and assuming it is " + Global::intToString(fixedBatchSize) + ", for this benchmark." << endl;
     else if(useHalfBatchSize)
       cout << "WARNING: Your nnMaxBatchSize is hardcoded to " + cfg.getString("nnMaxBatchSize") + ", ignoring it and assuming it is = threads/2, for this benchmark." << endl;
@@ -203,9 +255,20 @@ int MainCmds::benchmark(const vector<string>& args) {
   }
 
   NNEvaluator* nnEval = NULL;
-  auto reallocateNNEvalWithEnoughBatchSize = [&](int maxNumThreads) {
+  auto reallocateNNEval = [&](int batchSizeLimit, bool useExactMaxBatchSize) {
     if(nnEval != NULL)
       delete nnEval;
+    nnEval = createNNEval(
+      batchSizeLimit,
+      useExactMaxBatchSize,
+      *sgf,
+      modelFile,
+      logger,
+      cfg,
+      params
+    );
+  };
+  auto reallocateNNEvalWithEnoughBatchSize = [&](int maxNumThreads) {
     int batchSizeLimit;
     if(fixedBatchSize != -1)
       batchSizeLimit = fixedBatchSize;
@@ -213,7 +276,10 @@ int MainCmds::benchmark(const vector<string>& args) {
       batchSizeLimit = (maxNumThreads+1)/2;
     else
       batchSizeLimit = maxNumThreads;
-    nnEval = createNNEval(batchSizeLimit, *sgf, modelFile, logger, cfg, params);
+    reallocateNNEval(batchSizeLimit,false);
+  };
+  auto reallocateNNEvalForExactBatchSize = [&](int maxBatchSize) {
+    reallocateNNEval(maxBatchSize,true);
   };
   auto getDesiredBatchSize = [&](int currentNumThreads) {
     testAssert(nnEval != NULL);
@@ -224,7 +290,9 @@ int MainCmds::benchmark(const vector<string>& args) {
     return nnEval->getMaxBatchSize();
   };
 
-  if(!autoTuneThreads) {
+  if(tuneMaxBatchSize)
+    reallocateNNEvalForExactBatchSize(maxBatchSizesToTest[0]);
+  else if(!autoTuneThreads) {
     int maxThreads = 1;
     for(int i = 0; i<numThreadsToTest.size(); i++) {
       maxThreads = std::max(maxThreads,numThreadsToTest[i]);
@@ -271,14 +339,63 @@ int MainCmds::benchmark(const vector<string>& args) {
   cout << "Your GTP config is currently set to use numSearchThreads = " << params.numThreads << endl;
 
   vector<PlayUtils::BenchmarkResults> results;
-  if(!autoTuneThreads) {
+  vector<BatchSizeBenchmarkResult> batchSizeResults;
+  if(tuneMaxBatchSize) {
+    batchSizeResults = doFixedTuneBatchSizes(
+      params,
+      *sgf,
+      numPositionsPerGame,
+      nnEval,
+      logger,
+      secondsPerGameMove,
+      maxBatchSizesToTest,
+      numThreadsToTest,
+      reallocateNNEvalForExactBatchSize
+    );
+  }
+  else if(!autoTuneThreads) {
     results = doFixedTuneThreads(params,*sgf,numPositionsPerGame,nnEval,logger,secondsPerGameMove,numThreadsToTest,true,getDesiredBatchSize);
   }
   else {
     results = doAutoTuneThreads(params,*sgf,numPositionsPerGame,nnEval,logger,secondsPerGameMove,reallocateNNEvalWithEnoughBatchSize,getDesiredBatchSize);
   }
 
-  if(numThreadsToTest.size() > 1 || autoTuneThreads) {
+  if(tuneMaxBatchSize) {
+    testAssert(batchSizeResults.size() > 0);
+    int bestIdx = 0;
+    for(int i = 1; i<batchSizeResults.size(); i++) {
+      if(PlayUtils::BenchmarkResults::isBetterNNEvalsPerSecond(
+        batchSizeResults[i].benchmarkResult,
+        batchSizeResults[i].maxBatchSize,
+        batchSizeResults[bestIdx].benchmarkResult,
+        batchSizeResults[bestIdx].maxBatchSize
+      ))
+        bestIdx = i;
+    }
+
+    cout << "Ordered summary of max batch size and search thread combinations:" << endl;
+    cout << endl;
+    for(int i = 0; i<batchSizeResults.size(); i++) {
+      const BatchSizeBenchmarkResult& result = batchSizeResults[i];
+      cout << "nnMaxBatchSize = " << Global::strprintf("%2d",result.maxBatchSize) << ", "
+           << result.benchmarkResult.toString()
+           << (i == bestIdx ? " (highest nnEvals/s)" : "")
+           << endl;
+    }
+    cout << endl;
+
+    const BatchSizeBenchmarkResult& best = batchSizeResults[bestIdx];
+    cout << "Highest NN throughput among the tested combinations: nnMaxBatchSize = "
+         << best.maxBatchSize
+         << ", numSearchThreads = " << best.benchmarkResult.numThreads
+         << ", nnEvals/s = " << Global::strprintf("%.2f",best.benchmarkResult.getNNEvalsPerSecond())
+         << endl;
+    cout << "Exact ties prefer smaller nnMaxBatchSize, then fewer numSearchThreads." << endl;
+    cout << "This selection maximizes nnEvals/s only; it is not a playing-strength recommendation." << endl;
+    cout << "To use it, set nnMaxBatchSize and numSearchThreads in " << cfg.getFileName() << "." << endl;
+    cout << endl;
+  }
+  else if(numThreadsToTest.size() > 1 || autoTuneThreads) {
     PlayUtils::BenchmarkResults::printEloComparison(results,secondsPerGameMove);
 
     cout << "If you care about performance, you may want to edit numSearchThreads in " << cfg.getFileName() << " based on the above results!" << endl;
@@ -319,9 +436,19 @@ static void warmStartNNEval(const CompactSgf& sgf, Logger& logger, const SearchP
   delete bot;
 }
 
-static NNEvaluator* createNNEval(int maxNumThreads, const CompactSgf& sgf, const string& modelFile, Logger& logger, ConfigParser& cfg, const SearchParams& params) {
-  int expectedConcurrentEvals = maxNumThreads;
-  const int defaultMaxBatchSize = std::max(8,((maxNumThreads+3)/4)*4);
+static NNEvaluator* createNNEval(
+  int requestedMaxBatchSize,
+  bool useExactMaxBatchSize,
+  const CompactSgf& sgf,
+  const string& modelFile,
+  Logger& logger,
+  ConfigParser& cfg,
+  const SearchParams& params
+) {
+  int expectedConcurrentEvals = requestedMaxBatchSize;
+  const int defaultMaxBatchSize = useExactMaxBatchSize ?
+    std::max(1,requestedMaxBatchSize) :
+    std::max(8,((requestedMaxBatchSize+3)/4)*4);
 
   Rand seedRand;
 
@@ -414,6 +541,54 @@ static vector<PlayUtils::BenchmarkResults> doFixedTuneThreads(
     results.push_back(result);
   }
   cout << endl;
+  return results;
+}
+
+static vector<BatchSizeBenchmarkResult> doFixedTuneBatchSizes(
+  const SearchParams& params,
+  const CompactSgf& sgf,
+  int numPositionsPerGame,
+  NNEvaluator*& nnEval,
+  Logger& logger,
+  double secondsPerGameMove,
+  const vector<int>& maxBatchSizesToTest,
+  const vector<int>& numThreadsToTest,
+  const std::function<void(int)>& reallocateNNEvalForExactBatchSize
+) {
+  vector<BatchSizeBenchmarkResult> results;
+
+  cout << "Jointly testing exact max batch sizes and search thread counts "
+       << "(board size " << sgf.xSize << "x" << sgf.ySize << "):" << endl;
+  cout << endl;
+
+  for(int batchIdx = 0; batchIdx<maxBatchSizesToTest.size(); batchIdx++) {
+    const int maxBatchSize = maxBatchSizesToTest[batchIdx];
+    if(batchIdx > 0)
+      reallocateNNEvalForExactBatchSize(maxBatchSize);
+    testAssert(nnEval != NULL);
+    testAssert(nnEval->getMaxBatchSize() == maxBatchSize);
+
+    cout << "Testing exact nnMaxBatchSize = " << maxBatchSize
+         << " (evaluator max batch size = " << nnEval->getMaxBatchSize() << "):" << endl;
+    auto getDesiredBatchSize = [maxBatchSize](int numThreads) {
+      (void)numThreads;
+      return maxBatchSize;
+    };
+    vector<PlayUtils::BenchmarkResults> batchResults = doFixedTuneThreads(
+      params,
+      sgf,
+      numPositionsPerGame,
+      nnEval,
+      logger,
+      secondsPerGameMove,
+      numThreadsToTest,
+      false,
+      getDesiredBatchSize
+    );
+    for(const PlayUtils::BenchmarkResults& result: batchResults)
+      results.push_back({maxBatchSize,result});
+  }
+
   return results;
 }
 
@@ -916,7 +1091,7 @@ int MainCmds::genconfig(const vector<string>& args, const string& firstCommand) 
         return;
       if(nnEval != NULL)
         delete nnEval;
-      nnEval = createNNEval(maxNumThreads, *sgf, modelFile, logger, cfg, params);
+      nnEval = createNNEval(maxNumThreads,false,*sgf,modelFile,logger,cfg,params);
       maxNumThreadsForCurrentNNEval = maxNumThreads;
     };
     auto getDesiredBatchSize = [&](int currentNumThreads) {

--- a/cpp/command/benchmark.cpp
+++ b/cpp/command/benchmark.cpp
@@ -65,6 +65,17 @@ static vector<BatchSizeBenchmarkResult> doFixedTuneBatchSizes(
   const vector<int>& numThreadsToTest,
   const std::function<void(int)>& reallocateNNEvalForExactBatchSize
 );
+static void doAutoTuneBatchSize(
+  const SearchParams& params,
+  const CompactSgf& sgf,
+  int numPositionsPerGame,
+  NNEvaluator*& nnEval,
+  Logger& logger,
+  double secondsPerGameMove,
+  int maxBatchSize,
+  int profileBudget,
+  const std::function<void(int)>& reallocateNNEvalForExactBatchSize
+);
 
 #ifdef USE_EIGEN_BACKEND
 static const int64_t defaultMaxVisits = 80;
@@ -88,6 +99,9 @@ int MainCmds::benchmark(const vector<string>& args) {
   vector<int> maxBatchSizesToTest;
   int numPositionsPerGame;
   bool autoTuneThreads;
+  int autoTuneMaxBatchSize;
+  int autoTuneMaxBatchProfileBudget;
+  PlayUtils::BenchmarkTuneMode benchmarkTuneMode;
   int fixedBatchSize;
   bool useHalfBatchSize;
   double secondsPerGameMove;
@@ -114,6 +128,16 @@ int MainCmds::benchmark(const vector<string>& args) {
       "Test the Cartesian product of these exact max batch sizes and explicitly specified -threads, comma-separated (cannot use -tune)",
       false,"","BATCHES"
     );
+    TCLAP::ValueArg<int> autoTuneMaxBatchSizeArg(
+      "","tune-max-batch-size",
+      "Efficiently tune raw NN throughput over exact max batch sizes and thread counts, up to this memory-safe max batch size",
+      false,-1,"MAX"
+    );
+    TCLAP::ValueArg<int> autoTuneMaxBatchProfileBudgetArg(
+      "","tune-max-batch-profile-budget",
+      "Maximum number of unique exact max batch profiles to build during -tune-max-batch-size (default 6)",
+      false,6,"N"
+    );
     TCLAP::SwitchArg halfBatchSizeArg("","half-batch-size","Set max batch size to half of the number of threads");
     TCLAP::ValueArg<double> secondsPerGameMoveArg(
       "i","time",
@@ -134,6 +158,8 @@ int MainCmds::benchmark(const vector<string>& args) {
     cmd.add(autoTuneThreadsArg);
     cmd.add(fixedBatchSizeArg);
     cmd.add(maxBatchSizesArg);
+    cmd.add(autoTuneMaxBatchSizeArg);
+    cmd.add(autoTuneMaxBatchProfileBudgetArg);
     cmd.add(halfBatchSizeArg);
     cmd.add(secondsPerGameMoveArg);
     cmd.parseArgs(args);
@@ -145,9 +171,14 @@ int MainCmds::benchmark(const vector<string>& args) {
     string desiredThreadsStr = threadsArg.getValue();
     numPositionsPerGame = numPositionsPerGameArg.getValue();
     autoTuneThreads = autoTuneThreadsArg.getValue();
+    const bool autoTuneThreadsExplicitly = autoTuneThreadsArg.getValue();
     fixedBatchSize = fixedBatchSizeArg.getValue();
     string maxBatchSizesStr = maxBatchSizesArg.getValue();
     const bool maxBatchSizesSpecified = maxBatchSizesArg.isSet();
+    autoTuneMaxBatchSize = autoTuneMaxBatchSizeArg.getValue();
+    const bool autoTuneMaxBatchSizeSpecified = autoTuneMaxBatchSizeArg.isSet();
+    autoTuneMaxBatchProfileBudget = autoTuneMaxBatchProfileBudgetArg.getValue();
+    const bool autoTuneMaxBatchProfileBudgetSpecified = autoTuneMaxBatchProfileBudgetArg.isSet();
     useHalfBatchSize = halfBatchSizeArg.getValue();
     secondsPerGameMove = secondsPerGameMoveArg.getValue();
 
@@ -161,29 +192,33 @@ int MainCmds::benchmark(const vector<string>& args) {
       throw StringError("Number of positions per game to use: invalid value " + Global::intToString(numPositionsPerGame));
     if(secondsPerGameMove <= 0 || secondsPerGameMove > 1000000)
       throw StringError("Number of seconds per game move to assume: invalid value " + Global::doubleToString(secondsPerGameMove));
-    if(maxBatchSizesSpecified && autoTuneThreads)
-      throw StringError("Cannot combine max batch size tuning with automatic thread tuning");
-    if(desiredThreadsStr != "" && autoTuneThreads)
-      throw StringError("Cannot both automatically tune threads and specify fixed exact numbers of threads to test");
     if(fixedBatchSize != -1 && (fixedBatchSize <= 0 || fixedBatchSize > 65536))
       throw StringError("Invalid value for fixed batch size");
-    if(fixedBatchSize != -1 && useHalfBatchSize)
-      throw StringError("Cannot specify both fixed batch size and use half batch size");
-    if(maxBatchSizesSpecified && (fixedBatchSize != -1 || useHalfBatchSize))
-      throw StringError("Cannot combine max batch size tuning with fixed batch size or half batch size");
-    if(maxBatchSizesSpecified && desiredThreadsStr == "")
-      throw StringError("Max batch size tuning requires an explicit list of thread counts using -threads");
+    if(autoTuneMaxBatchSizeSpecified && (autoTuneMaxBatchSize < 2 || autoTuneMaxBatchSize > 65536))
+      throw StringError("Automatic max batch size tuning requires MAX to be between 2 and 65536");
+    if(autoTuneMaxBatchProfileBudget < 2 || autoTuneMaxBatchProfileBudget > 256)
+      throw StringError("Automatic max batch profile budget must be between 2 and 256");
+
+    benchmarkTuneMode = PlayUtils::getBenchmarkTuneMode(
+      autoTuneThreadsExplicitly,
+      threadsArg.isSet(),
+      maxBatchSizesSpecified,
+      autoTuneMaxBatchSizeSpecified,
+      fixedBatchSize != -1,
+      useHalfBatchSize,
+      autoTuneMaxBatchProfileBudgetSpecified
+    );
+    autoTuneThreads = benchmarkTuneMode == PlayUtils::BENCHMARK_TUNE_AUTO_THREADS;
 
     if(maxBatchSizesSpecified)
       maxBatchSizesToTest = KataGoCommandLine::parseCommaSeparatedUniqueInts(
         maxBatchSizesStr,1,65536,"Max batch size to test"
       );
 
-    //Apply default
-    if(desiredThreadsStr == "")
-      autoTuneThreads = true;
-
-    if(!autoTuneThreads) {
+    if(
+      benchmarkTuneMode == PlayUtils::BENCHMARK_TUNE_FIXED_THREADS ||
+      benchmarkTuneMode == PlayUtils::BENCHMARK_TUNE_EXPLICIT_BATCH_GRID
+    ) {
       vector<string> desiredThreadsPieces = Global::split(desiredThreadsStr,',');
       for(int i = 0; i<desiredThreadsPieces.size(); i++) {
         string s = Global::trim(desiredThreadsPieces[i]);
@@ -237,14 +272,15 @@ int MainCmds::benchmark(const vector<string>& args) {
 
   Setup::initializeSession(cfg);
 
-  const bool tuneMaxBatchSize = maxBatchSizesToTest.size() > 0;
+  const bool tuneMaxBatchSize = benchmarkTuneMode == PlayUtils::BENCHMARK_TUNE_EXPLICIT_BATCH_GRID;
+  const bool autoTuneBatchSize = benchmarkTuneMode == PlayUtils::BENCHMARK_TUNE_AUTO_BATCH;
 #ifdef USE_EIGEN_BACKEND
-  if(tuneMaxBatchSize)
+  if(tuneMaxBatchSize || autoTuneBatchSize)
     throw StringError("Max batch size tuning is not supported by the Eigen backend");
 #endif
 
   if(cfg.contains("nnMaxBatchSize")) {
-    if(tuneMaxBatchSize)
+    if(tuneMaxBatchSize || autoTuneBatchSize)
       cout << "WARNING: Your nnMaxBatchSize is hardcoded to " + cfg.getString("nnMaxBatchSize") + ", ignoring it while tuning max batch size for this benchmark." << endl;
     else if(fixedBatchSize != -1)
       cout << "WARNING: Your nnMaxBatchSize is hardcoded to " + cfg.getString("nnMaxBatchSize") + ", ignoring it and assuming it is " + Global::intToString(fixedBatchSize) + ", for this benchmark." << endl;
@@ -292,6 +328,8 @@ int MainCmds::benchmark(const vector<string>& args) {
 
   if(tuneMaxBatchSize)
     reallocateNNEvalForExactBatchSize(maxBatchSizesToTest[0]);
+  else if(autoTuneBatchSize)
+    reallocateNNEvalForExactBatchSize(autoTuneMaxBatchSize);
   else if(!autoTuneThreads) {
     int maxThreads = 1;
     for(int i = 0; i<numThreadsToTest.size(); i++) {
@@ -340,7 +378,20 @@ int MainCmds::benchmark(const vector<string>& args) {
 
   vector<PlayUtils::BenchmarkResults> results;
   vector<BatchSizeBenchmarkResult> batchSizeResults;
-  if(tuneMaxBatchSize) {
+  if(autoTuneBatchSize) {
+    doAutoTuneBatchSize(
+      params,
+      *sgf,
+      numPositionsPerGame,
+      nnEval,
+      logger,
+      secondsPerGameMove,
+      autoTuneMaxBatchSize,
+      autoTuneMaxBatchProfileBudget,
+      reallocateNNEvalForExactBatchSize
+    );
+  }
+  else if(tuneMaxBatchSize) {
     batchSizeResults = doFixedTuneBatchSizes(
       params,
       *sgf,
@@ -590,6 +641,261 @@ static vector<BatchSizeBenchmarkResult> doFixedTuneBatchSizes(
   }
 
   return results;
+}
+
+static PlayUtils::BenchmarkResults runRawBenchmarkCase(
+  const SearchParams& params,
+  const CompactSgf& sgf,
+  int numPositionsPerGame,
+  NNEvaluator* nnEval,
+  Logger& logger,
+  double secondsPerGameMove,
+  int maxBatchSize,
+  int numThreads
+) {
+  testAssert(nnEval != NULL);
+  testAssert(nnEval->getMaxBatchSize() == maxBatchSize);
+  SearchParams thisParams = params;
+  setNumThreads(thisParams,nnEval,logger,numThreads,maxBatchSize,sgf);
+  return PlayUtils::benchmarkSearchOnPositionsAndPrint(
+    thisParams,
+    sgf,
+    numPositionsPerGame,
+    nnEval,
+    NULL,
+    secondsPerGameMove,
+    false
+  );
+}
+
+static void doAutoTuneBatchSize(
+  const SearchParams& params,
+  const CompactSgf& sgf,
+  int numPositionsPerGame,
+  NNEvaluator*& nnEval,
+  Logger& logger,
+  double secondsPerGameMove,
+  int maxBatchSize,
+  int profileBudget,
+  const std::function<void(int)>& reallocateNNEvalForExactBatchSize
+) {
+  testAssert(nnEval != NULL);
+  testAssert(nnEval->getMaxBatchSize() == maxBatchSize);
+  const int numServerThreads = nnEval->getNumServerThreads();
+  testAssert(numServerThreads > 0);
+  const vector<int> scoutThreads = PlayUtils::getAutoBatchScoutThreads(numServerThreads,maxBatchSize);
+  const int actualProfileBudget = std::min(profileBudget,maxBatchSize);
+  const int estimatedCases = (int)scoutThreads.size() + 3*(actualProfileBudget-1) + 4;
+
+  cout << "Automatically tuning exact max batch size and search threads for raw NN throughput "
+       << "(board size " << sgf.xSize << "x" << sgf.ySize << "):" << endl;
+  cout << "  Memory-safe maximum nnMaxBatchSize: " << maxBatchSize << endl;
+  cout << "  Hard limit: at most " << actualProfileBudget << " unique exact profiles and "
+       << estimatedCases << " measured benchmark cases (including four A-B-B-A confirmations)." << endl;
+  cout << "  Wide scout thread counts: ";
+  for(int i = 0; i<scoutThreads.size(); i++)
+    cout << (i == 0 ? "" : ",") << scoutThreads[i];
+  cout << endl;
+  cout << endl;
+
+  auto maxBatchGetter = [maxBatchSize](int numThreads) noexcept {
+    (void)numThreads;
+    return maxBatchSize;
+  };
+  cout << "Wide scout using the exact MAX profile nnMaxBatchSize = " << maxBatchSize << ":" << endl;
+  vector<PlayUtils::BenchmarkResults> scoutResults = doFixedTuneThreads(
+    params,
+    sgf,
+    numPositionsPerGame,
+    nnEval,
+    logger,
+    secondsPerGameMove,
+    scoutThreads,
+    false,
+    maxBatchGetter
+  );
+  const int centerBatchSize = PlayUtils::getAutoBatchScoutBatchSize(scoutResults,maxBatchSize);
+
+  int bestScoutIdx = 0;
+  for(int i = 1; i<scoutResults.size(); i++) {
+    if(PlayUtils::BenchmarkResults::isBetterNNEvalsPerSecond(
+      scoutResults[i],maxBatchSize,scoutResults[bestScoutIdx],maxBatchSize
+    ))
+      bestScoutIdx = i;
+  }
+  int scoutWindowStart = std::max(0,bestScoutIdx-1);
+  if(scoutWindowStart+3 > scoutResults.size())
+    scoutWindowStart = std::max(0,(int)scoutResults.size()-3);
+  vector<PlayUtils::BenchmarkResults> scoutMedianResults;
+  for(int i = scoutWindowStart; i<scoutResults.size() && i<scoutWindowStart+3; i++)
+    scoutMedianResults.push_back(scoutResults[i]);
+
+  vector<PlayUtils::AutoBatchProfileResult> profileResults;
+  profileResults.push_back(
+    PlayUtils::summarizeAutoBatchProfile(maxBatchSize,scoutMedianResults)
+  );
+  const vector<int> profileCandidates = PlayUtils::getAutoBatchProfileCandidates(
+    maxBatchSize,
+    centerBatchSize,
+    profileBudget
+  );
+  cout << "Scout peak average batch size rounded to B0 = " << centerBatchSize << "." << endl;
+  cout << "Unique exact profiles within budget: ";
+  for(int i = 0; i<profileCandidates.size(); i++)
+    cout << (i == 0 ? "" : ",") << profileCandidates[i];
+  cout << endl;
+  cout << endl;
+
+  for(int i = 1; i<profileCandidates.size(); i++) {
+    const int batchSize = profileCandidates[i];
+    reallocateNNEvalForExactBatchSize(batchSize);
+    testAssert(nnEval != NULL);
+    testAssert(nnEval->getMaxBatchSize() == batchSize);
+    const vector<int> stencil = PlayUtils::getAutoBatchThreadStencil(batchSize,numServerThreads);
+    cout << "Testing exact nnMaxBatchSize = " << batchSize << " at three local thread counts: ";
+    for(int j = 0; j<stencil.size(); j++)
+      cout << (j == 0 ? "" : ",") << stencil[j];
+    cout << endl;
+    vector<PlayUtils::BenchmarkResults> trials;
+    for(int numThreads: stencil)
+      trials.push_back(runRawBenchmarkCase(
+        params,sgf,numPositionsPerGame,nnEval,logger,secondsPerGameMove,batchSize,numThreads
+      ));
+    profileResults.push_back(PlayUtils::summarizeAutoBatchProfile(batchSize,trials));
+    cout << endl;
+  }
+
+  testAssert(profileResults.size() >= 2);
+  vector<int> rankedProfileIdxs(profileResults.size());
+  for(int i = 0; i<rankedProfileIdxs.size(); i++)
+    rankedProfileIdxs[i] = i;
+  std::stable_sort(
+    rankedProfileIdxs.begin(),
+    rankedProfileIdxs.end(),
+    [&](int x, int y) {
+      return PlayUtils::isBetterAutoBatchProfile(profileResults[x],profileResults[y]);
+    }
+  );
+
+  cout << "Profile ranking by median raw nnEvals/s (the best raw thread is retained as finalist):" << endl;
+  for(int rank = 0; rank<rankedProfileIdxs.size(); rank++) {
+    const PlayUtils::AutoBatchProfileResult& profile = profileResults[rankedProfileIdxs[rank]];
+    cout << "  nnMaxBatchSize = " << profile.maxBatchSize
+         << ", median nnEvals/s = " << Global::strprintf("%.2f",profile.medianNNEvalsPerSecond)
+         << ", finalist threads = " << profile.finalist.numThreads
+         << ", finalist nnEvals/s = " << Global::strprintf("%.2f",profile.finalist.getNNEvalsPerSecond())
+         << endl;
+  }
+  cout << endl;
+
+  const PlayUtils::AutoBatchProfileResult& finalistA = profileResults[rankedProfileIdxs[0]];
+  const PlayUtils::AutoBatchProfileResult& finalistB = profileResults[rankedProfileIdxs[1]];
+  vector<PlayUtils::BenchmarkResults> confirmationsA;
+  vector<PlayUtils::BenchmarkResults> confirmationsB;
+  auto confirm = [&](const PlayUtils::AutoBatchProfileResult& finalist, char label) {
+    // Give every confirmation the same evaluator warmup state. In particular,
+    // do not let the middle B-B pair alone reuse CUDA Graphs or other context state.
+    reallocateNNEvalForExactBatchSize(finalist.maxBatchSize);
+    testAssert(nnEval->getMaxBatchSize() == finalist.maxBatchSize);
+    cout << "Confirmation " << label
+         << ": nnMaxBatchSize = " << finalist.maxBatchSize
+         << ", numSearchThreads = " << finalist.finalist.numThreads << endl;
+    return runRawBenchmarkCase(
+      params,
+      sgf,
+      numPositionsPerGame,
+      nnEval,
+      logger,
+      secondsPerGameMove,
+      finalist.maxBatchSize,
+      finalist.finalist.numThreads
+    );
+  };
+
+  cout << "Confirming the top two different max batch sizes in A-B-B-A order:" << endl;
+  confirmationsA.push_back(confirm(finalistA,'A'));
+  confirmationsB.push_back(confirm(finalistB,'B'));
+  confirmationsB.push_back(confirm(finalistB,'B'));
+  confirmationsA.push_back(confirm(finalistA,'A'));
+  cout << endl;
+
+  const bool aWins = PlayUtils::isBetterAutoBatchConfirmation(
+    finalistA.maxBatchSize,
+    finalistA.finalist.numThreads,
+    confirmationsA,
+    finalistB.maxBatchSize,
+    finalistB.finalist.numThreads,
+    confirmationsB
+  );
+  const PlayUtils::AutoBatchProfileResult& winner = aWins ? finalistA : finalistB;
+  const vector<PlayUtils::BenchmarkResults>& winnerConfirmations = aWins ? confirmationsA : confirmationsB;
+  const double pooledA = PlayUtils::getPooledNNEvalsPerSecond(confirmationsA);
+  const double pooledB = PlayUtils::getPooledNNEvalsPerSecond(confirmationsB);
+  auto jitterPercent = [](const vector<PlayUtils::BenchmarkResults>& confirmations) {
+    testAssert(confirmations.size() == 2);
+    const double rate0 = confirmations[0].getNNEvalsPerSecond();
+    const double rate1 = confirmations[1].getNNEvalsPerSecond();
+    const double mean = 0.5*(rate0+rate1);
+    return mean > 0.0 ? 100.0 * fabs(rate0-rate1) / mean : 0.0;
+  };
+
+  cout << "A-B-B-A confirmation (pooled sum(nnEvals) / sum(seconds), not an average of rates):" << endl;
+  cout << "  A: nnMaxBatchSize = " << finalistA.maxBatchSize
+       << ", numSearchThreads = " << finalistA.finalist.numThreads
+       << ", pooled nnEvals/s = " << Global::strprintf("%.2f",pooledA)
+       << ", two-run jitter = " << Global::strprintf("%.2f%%",jitterPercent(confirmationsA))
+       << endl;
+  cout << "  B: nnMaxBatchSize = " << finalistB.maxBatchSize
+       << ", numSearchThreads = " << finalistB.finalist.numThreads
+       << ", pooled nnEvals/s = " << Global::strprintf("%.2f",pooledB)
+       << ", two-run jitter = " << Global::strprintf("%.2f%%",jitterPercent(confirmationsB))
+       << endl;
+  cout << "Selected raw-throughput result: nnMaxBatchSize = " << winner.maxBatchSize
+       << ", numSearchThreads = " << winner.finalist.numThreads
+       << ", confirmed nnEvals/s = "
+       << Global::strprintf("%.2f",PlayUtils::getPooledNNEvalsPerSecond(winnerConfirmations))
+       << endl;
+  cout << "Exact confirmation ties prefer smaller nnMaxBatchSize, then fewer numSearchThreads." << endl;
+
+  vector<int> testedBatchSizes;
+  for(const PlayUtils::AutoBatchProfileResult& profile: profileResults)
+    testedBatchSizes.push_back(profile.maxBatchSize);
+  sort(testedBatchSizes.begin(),testedBatchSizes.end());
+  cout << "Tested nnMaxBatchSize values: ";
+  for(int i = 0; i<testedBatchSizes.size(); i++)
+    cout << (i == 0 ? "" : ",") << testedBatchSizes[i];
+  cout << endl;
+  const int maxUntestedGap = PlayUtils::getMaxUntestedBatchSizeGap(testedBatchSizes,maxBatchSize);
+  cout << "Largest untested integer max-batch gap within 1.." << maxBatchSize
+       << ": " << maxUntestedGap << endl;
+  if(winner.maxBatchSize == 1 || winner.maxBatchSize == maxBatchSize)
+    cout << "WARNING: The winner is on the tested batch-size boundary; consider raising MAX or checking the boundary explicitly." << endl;
+  if(maxUntestedGap > 0)
+    cout << "WARNING: A finite profile budget cannot guarantee finding an isolated non-smooth tactic or backend spike inside untested gaps." << endl;
+
+  vector<PlayUtils::BenchmarkResults> winnerInitialTrials = winner.trials;
+  std::stable_sort(
+    winnerInitialTrials.begin(),
+    winnerInitialTrials.end(),
+    [&](const PlayUtils::BenchmarkResults& x, const PlayUtils::BenchmarkResults& y) {
+      return PlayUtils::BenchmarkResults::isBetterNNEvalsPerSecond(
+        x,winner.maxBatchSize,y,winner.maxBatchSize
+      );
+    }
+  );
+  if(winnerInitialTrials.size() >= 2) {
+    const double bestRate = winnerInitialTrials[0].getNNEvalsPerSecond();
+    const double secondRate = winnerInitialTrials[1].getNNEvalsPerSecond();
+    if(bestRate > 0.0 && secondRate >= 0.995*bestRate) {
+      cout << "The runner-up thread count for the winning batch size was within 0.5%. "
+           << "For a finer decision, explicitly benchmark -max-batch-sizes "
+           << winner.maxBatchSize << " -threads "
+           << winnerInitialTrials[0].numThreads << "," << winnerInitialTrials[1].numThreads
+           << " in balanced order." << endl;
+    }
+  }
+  cout << "This selection maximizes raw nnEvals/s only; it is not a playing-strength recommendation." << endl;
+  cout << endl;
 }
 
 static vector<PlayUtils::BenchmarkResults> doAutoTuneThreads(

--- a/cpp/command/commandline.cpp
+++ b/cpp/command/commandline.cpp
@@ -185,6 +185,29 @@ KataGoCommandLine::~KataGoCommandLine() {
   delete helpOutput;
 }
 
+vector<int> KataGoCommandLine::parseCommaSeparatedUniqueInts(
+  const string& values,
+  int minValue,
+  int maxValue,
+  const string& valueDescription
+) {
+  testAssert(minValue <= maxValue);
+  vector<string> pieces = Global::split(values,',');
+  vector<int> parsedValues;
+  for(const string& piece: pieces) {
+    const string s = Global::trim(piece);
+    int parsed;
+    if(s == "" || !Global::tryStringToInt(s,parsed) || parsed < minValue || parsed > maxValue)
+      throw StringError(valueDescription + ": invalid value: " + s);
+    if(std::find(parsedValues.begin(),parsedValues.end(),parsed) != parsedValues.end())
+      throw StringError(valueDescription + ": duplicate value: " + s);
+    parsedValues.push_back(parsed);
+  }
+  if(parsedValues.size() <= 0)
+    throw StringError("Must specify at least one " + valueDescription);
+  return parsedValues;
+}
+
 
 string KataGoCommandLine::defaultGtpConfigFileName() {
   return "default_gtp.cfg";

--- a/cpp/command/commandline.h
+++ b/cpp/command/commandline.h
@@ -24,6 +24,12 @@ class KataGoCommandLine : public TCLAP::CmdLine
   ~KataGoCommandLine();
 
   static std::string defaultGtpConfigFileName();
+  static std::vector<int> parseCommaSeparatedUniqueInts(
+    const std::string& values,
+    int minValue,
+    int maxValue,
+    const std::string& valueDescription
+  );
 
   void parseArgs(const std::vector<std::string>& args);
 

--- a/cpp/command/runtests.cpp
+++ b/cpp/command/runtests.cpp
@@ -37,6 +37,7 @@ int MainCmds::runtests(const vector<string>& args) {
   ComputeElos::runTests();
   Base64::runTests();
   ThreadTest::runTests();
+  Tests::runBenchmarkResultsTests();
 
   Tests::runBoardIOTests();
   Tests::runBoardBasicTests();

--- a/cpp/configs/gtp_example.cfg
+++ b/cpp/configs/gtp_example.cfg
@@ -410,6 +410,16 @@ searchFactorWhenWinningThreshold = 0.95
 # ------------------------------
 # These only apply when using the TENSORRT version of KataGo.
 
+# CUDA Graphs can reduce neural-net launch overhead, especially at small batch
+# sizes. This requires TensorRT 8.6 or newer and adds initialization time and
+# persistent CPU/GPU memory for each captured batch size and NN server thread.
+# trtUseCudaGraph = false
+
+# Capture graph batch sizes from 1 through this limit. Larger batches use the
+# normal TensorRT enqueue path. Increase this only when the extra memory use is
+# acceptable; the effective limit is capped by nnMaxBatchSize.
+# trtCudaGraphMaxBatchSize = 16
+
 # For one GPU: optionally uncomment this option and change if the GPU to
 # use is not device 0.
 # trtDeviceToUse = 0

--- a/cpp/neuralnet/trtbackend.cpp
+++ b/cpp/neuralnet/trtbackend.cpp
@@ -47,6 +47,26 @@ struct CudaMemoryDeleter {
 };
 using CudaMemory = unique_ptr<void, CudaMemoryDeleter>;
 
+struct CudaHostMemoryDeleter {
+  void operator()(float* ptr) const noexcept {
+    if(ptr != nullptr)
+      cudaFreeHost(ptr);
+  }
+};
+using CudaHostFloatArray = unique_ptr<float[], CudaHostMemoryDeleter>;
+
+static CudaHostFloatArray allocateCudaHostFloats(size_t numFloats) {
+  if(numFloats == 0)
+    return CudaHostFloatArray(nullptr);
+  void* rawPtr = nullptr;
+  // InputBuffers is allocated before its NN server thread selects a GPU. Portable registration
+  // keeps the allocation pinned when different server threads target different CUDA contexts.
+  CUDA_ERR(
+    "allocateCudaHostFloats",
+    cudaHostAlloc(&rawPtr, numFloats * sizeof(float), cudaHostAllocPortable));
+  return CudaHostFloatArray(static_cast<float*>(rawPtr));
+}
+
 // Write `data` to `path` atomically, so a reader either sees the complete
 // old file or the complete new one, never a torn/truncated write from a crash or a racing process.
 static void writeFileAtomically(const string& path, const char* data, size_t size) {
@@ -82,6 +102,8 @@ void NeuralNet::globalCleanup() {
   // Empty for TensorRT backend
 }
 
+struct SharedTRTEngine;
+
 struct ComputeContext {
   int nnXLen;
   int nnYLen;
@@ -92,6 +114,8 @@ struct ComputeContext {
   bool useCudaGraph;
   int cudaGraphMaxBatchSize;
   string dumpDebugPlanToDir;  // if non-empty, dump emitted ONNX + built-engine layer info here (debug)
+  mutex sharedEnginesMutex;
+  map<string, weak_ptr<SharedTRTEngine>> sharedEngines;
 };
 
 ComputeContext* NeuralNet::createComputeContext(
@@ -1151,6 +1175,27 @@ struct TRTErrorRecorder : IErrorRecorder {
   }
 };
 
+struct SharedTRTEngine {
+  TRTLogger trtLogger;
+  TRTErrorRecorder trtErrorRecorder;
+  unique_ptr<IRuntime> runtime;
+  unique_ptr<ICudaEngine> engine;
+  bool usingFP16;
+  vector<pair<string, string>> debugOutputs;
+
+  SharedTRTEngine()
+    :trtLogger(),
+     trtErrorRecorder(),
+     runtime(),
+     engine(),
+     usingFP16(false),
+     debugOutputs()
+  {}
+
+  SharedTRTEngine(const SharedTRTEngine&) = delete;
+  SharedTRTEngine& operator=(const SharedTRTEngine&) = delete;
+};
+
 
 struct ComputeHandle {
   struct CudaGraphEntry {
@@ -1179,10 +1224,9 @@ struct ComputeHandle {
   int modelVersion;
   vector<pair<string, string>> debugOutputs;
 
-  TRTLogger trtLogger;
   TRTErrorRecorder trtErrorRecorder;
-  unique_ptr<IRuntime> runtime;
-  unique_ptr<ICudaEngine> engine;
+  shared_ptr<SharedTRTEngine> sharedEngine;
+  ICudaEngine* engine;
   CudaMemory executionDeviceMemory;
   size_t executionDeviceMemoryBytes;
   map<string, CudaMemory> buffers;
@@ -1200,6 +1244,8 @@ struct ComputeHandle {
     bool requireExactNNLen) {
     ctx = context;
     externalLogger = logger;
+    usingFP16 = false;
+    engine = nullptr;
     executionDeviceMemoryBytes = 0;
     cudaGraphsEnabled = ctx->useCudaGraph;
 
@@ -1224,7 +1270,48 @@ struct ComputeHandle {
       throw StringError("TensorRT backend: detected incompatible version of TensorRT library");
     }
 
-    trtLogger.setLogger(logger);
+    trtErrorRecorder.setLogger(logger);
+
+    const bool dumpDebugPlan = !ctx->dumpDebugPlanToDir.empty();
+    string dumpDebugBasePath;
+    auto initializeDebugDumpPath = [&]() {
+      if(!dumpDebugPlan || !dumpDebugBasePath.empty())
+        return;
+      MakeDir::make(ctx->dumpDebugPlanToDir);
+      dumpDebugBasePath = ctx->dumpDebugPlanToDir + "/plan_" +
+        Global::intToString(ctx->nnXLen) + "x" + Global::intToString(ctx->nnYLen) +
+        (usingFP16 ? "_fp16" : "_fp32") + (requireExactNNLen ? "_exact" : "_max");
+    };
+
+    // TensorRT 10 supports the standard concurrency model of one shared, immutable engine with a
+    // separate execution context per host thread. Reuse the engine for handles targeting the same
+    // GPU, while retaining private contexts, activation memory, I/O buffers, and CUDA Graphs.
+#if NV_TENSORRT_MAJOR >= 10
+    unique_lock<mutex> sharedEngineLock;
+    string sharedEngineKey;
+    int currentDevice = -1;
+    CUDA_ERR("ComputeHandle", cudaGetDevice(&currentDevice));
+    sharedEngineKey = Global::strprintf(
+      "%d:%d:%d:%s",
+      currentDevice,
+      maxBatchSize,
+      requireExactNNLen ? 1 : 0,
+      loadedModel->modelDesc.sha256.c_str());
+    sharedEngineLock = unique_lock<mutex>(ctx->sharedEnginesMutex);
+    auto cachedEngine = ctx->sharedEngines.find(sharedEngineKey);
+    if(cachedEngine != ctx->sharedEngines.end())
+      sharedEngine = cachedEngine->second.lock();
+    if(sharedEngine != nullptr && logger != nullptr) {
+      logger->write(
+        "TensorRT backend: reusing shared engine for concurrent execution contexts on GPU " +
+        Global::intToString(currentDevice));
+    }
+#endif
+
+    if(sharedEngine == nullptr) {
+      auto newSharedEngine = make_shared<SharedTRTEngine>();
+      TRTLogger& trtLogger = newSharedEngine->trtLogger;
+      trtLogger.setLogger(logger);
 
     const bool useOnnxEmit = ctx->useOnnx;
 
@@ -1237,7 +1324,6 @@ struct ComputeHandle {
       throw StringError("TensorRT backend: failed to create builder config");
     }
 
-    usingFP16 = false;
     if(builder->platformHasFastFp16()) {
       if(ctx->useFP16Mode == enabled_t::True || ctx->useFP16Mode == enabled_t::Auto) {
         config->setFlag(BuilderFlag::kFP16);
@@ -1253,14 +1339,7 @@ struct ComputeHandle {
 
     // Debug plan/engine dump (trtDumpDebugPlanToDir). Build a base path inside that dir, disambiguated
     // by board size + precision + exact/max so the multiple engines built in one process don't collide.
-    const bool dumpDebugPlan = !ctx->dumpDebugPlanToDir.empty();
-    string dumpDebugBasePath;
-    if(dumpDebugPlan) {
-      MakeDir::make(ctx->dumpDebugPlanToDir);
-      dumpDebugBasePath = ctx->dumpDebugPlanToDir + "/plan_" +
-        Global::intToString(ctx->nnXLen) + "x" + Global::intToString(ctx->nnYLen) +
-        (usingFP16 ? "_fp16" : "_fp32") + (requireExactNNLen ? "_exact" : "_max");
-    }
+    initializeDebugDumpPath();
 
     auto network = unique_ptr<INetworkDefinition>(
       builder->createNetworkV2(1U << static_cast<int>(NetworkDefinitionCreationFlag::kEXPLICIT_BATCH)));
@@ -1604,17 +1683,34 @@ struct ComputeHandle {
       logger->write("TensorRT backend: dumped serialized plan to " + planPath);
     }
 
-    runtime.reset(createInferRuntime(trtLogger));
-    if(!runtime) {
+    newSharedEngine->runtime.reset(createInferRuntime(trtLogger));
+    if(!newSharedEngine->runtime) {
       throw StringError("TensorRT backend: failed to create runtime");
     }
-    trtErrorRecorder.setLogger(logger);
-    runtime->setErrorRecorder(&trtErrorRecorder);
+    newSharedEngine->trtErrorRecorder.setLogger(logger);
+    newSharedEngine->runtime->setErrorRecorder(&newSharedEngine->trtErrorRecorder);
 
-    engine.reset(runtime->deserializeCudaEngine(plan.data(), plan.size()));
-    if(!engine) {
+    newSharedEngine->engine.reset(newSharedEngine->runtime->deserializeCudaEngine(plan.data(), plan.size()));
+    if(!newSharedEngine->engine) {
       throw StringError("TensorRT backend: failed to create cuda engine");
     }
+    newSharedEngine->trtErrorRecorder.clear();
+
+      newSharedEngine->usingFP16 = usingFP16;
+      newSharedEngine->debugOutputs = debugOutputs;
+      sharedEngine = std::move(newSharedEngine);
+#if NV_TENSORRT_MAJOR >= 10
+      ctx->sharedEngines[sharedEngineKey] = sharedEngine;
+#endif
+    }
+#if NV_TENSORRT_MAJOR >= 10
+    sharedEngineLock.unlock();
+#endif
+
+    usingFP16 = sharedEngine->usingFP16;
+    debugOutputs = sharedEngine->debugOutputs;
+    engine = sharedEngine->engine.get();
+    initializeDebugDumpPath();
 
     if(cudaGraphsEnabled) {
 #if NV_TENSORRT_MAJOR > 10 || (NV_TENSORRT_MAJOR == 10 && NV_TENSORRT_MINOR >= 1)
@@ -1647,6 +1743,7 @@ struct ComputeHandle {
     if(!exec) {
       throw StringError("TensorRT backend: failed to create execution context");
     }
+    exec->setErrorRecorder(&trtErrorRecorder);
 
     // For the debug plan dump, write the built engine's per-layer info (precision, format, tactic) as
     // JSON. This shows the realized graph: which ops fused (Myelin kgen/gemm kernels), the per-tensor
@@ -1778,6 +1875,7 @@ struct ComputeHandle {
       return nullptr;
     }
 
+    graphContext->setErrorRecorder(&trtErrorRecorder);
     setExecutionDeviceMemory(graphContext.get());
     for(int i = 0; i < engine->getNbIOTensors(); i++) {
       const char* name = engine->getIOTensorName(i);
@@ -2079,15 +2177,15 @@ struct InputBuffers {
   size_t scoreValueResultBufferBytes;
   size_t ownershipResultBufferBytes;
 
-  unique_ptr<float[]> maskInputs;           // Host pointer
-  unique_ptr<float[]> spatialInputs;        // Host pointer
-  unique_ptr<float[]> globalInputs;  // Host pointer
-  unique_ptr<float[]> metaInputs;  // Host pointer
-  unique_ptr<float[]> policyPassResults;    // Host pointer
-  unique_ptr<float[]> policyResults;        // Host pointer
-  unique_ptr<float[]> valueResults;         // Host pointer
-  unique_ptr<float[]> scoreValueResults;    // Host pointer
-  unique_ptr<float[]> ownershipResults;     // Host pointer
+  CudaHostFloatArray maskInputs;
+  CudaHostFloatArray spatialInputs;
+  CudaHostFloatArray globalInputs;
+  CudaHostFloatArray metaInputs;
+  CudaHostFloatArray policyPassResults;
+  CudaHostFloatArray policyResults;
+  CudaHostFloatArray valueResults;
+  CudaHostFloatArray scoreValueResults;
+  CudaHostFloatArray ownershipResults;
 
   InputBuffers(const LoadedModel* loadedModel, int maxBatchSz, int nnXLen, int nnYLen) {
     const ModelDesc& m = loadedModel->modelDesc;
@@ -2135,15 +2233,15 @@ struct InputBuffers {
     scoreValueResultBufferBytes = maxBatchSize * singleScoreValueResultBytes;
     ownershipResultBufferBytes = maxBatchSize * singleOwnershipResultBytes;
 
-    maskInputs = make_unique<float[]>(maxBatchSize * singleMaskElts);
-    spatialInputs = make_unique<float[]>(maxBatchSize * singleInputElts);
-    globalInputs = make_unique<float[]>(maxBatchSize * singleInputGlobalElts);
-    metaInputs = make_unique<float[]>(maxBatchSize * singleInputMetaElts);
-    policyPassResults = make_unique<float[]>(maxBatchSize * singlePolicyPassResultElts);
-    policyResults = make_unique<float[]>(maxBatchSize * singlePolicyResultElts);
-    valueResults = make_unique<float[]>(maxBatchSize * singleValueResultElts);
-    scoreValueResults = make_unique<float[]>(maxBatchSize * singleScoreValueResultElts);
-    ownershipResults = make_unique<float[]>(maxBatchSize * singleOwnershipResultElts);
+    maskInputs = allocateCudaHostFloats(maxBatchSize * singleMaskElts);
+    spatialInputs = allocateCudaHostFloats(maxBatchSize * singleInputElts);
+    globalInputs = allocateCudaHostFloats(maxBatchSize * singleInputGlobalElts);
+    metaInputs = allocateCudaHostFloats(maxBatchSize * singleInputMetaElts);
+    policyPassResults = allocateCudaHostFloats(maxBatchSize * singlePolicyPassResultElts);
+    policyResults = allocateCudaHostFloats(maxBatchSize * singlePolicyResultElts);
+    valueResults = allocateCudaHostFloats(maxBatchSize * singleValueResultElts);
+    scoreValueResults = allocateCudaHostFloats(maxBatchSize * singleScoreValueResultElts);
+    ownershipResults = allocateCudaHostFloats(maxBatchSize * singleOwnershipResultElts);
   }
 
   InputBuffers() = delete;
@@ -2183,17 +2281,16 @@ void NeuralNet::getOutput(
     float* rowMaskInput = &inputBuffers->maskInputs[inputBuffers->singleMaskElts * nIdx];
     float* rowSpatialInput = &inputBuffers->spatialInputs[inputBuffers->singleInputElts * nIdx];
     float* rowGlobalInput = &inputBuffers->globalInputs[inputBuffers->singleInputGlobalElts * nIdx];
-    float* rowMetaInput = &inputBuffers->metaInputs[inputBuffers->singleInputMetaElts * nIdx];
 
     const float* rowGlobal = inputBufs[nIdx]->rowGlobalBuf.data();
     const float* rowSpatial = inputBufs[nIdx]->rowSpatialBuf.data();
     const float* rowMeta = inputBufs[nIdx]->rowMetaBuf.data();
     const bool hasRowMeta = inputBufs[nIdx]->hasRowMeta;
-    copy(rowGlobal, rowGlobal + numGlobalFeatures, rowGlobalInput);
     std::copy(rowGlobal,rowGlobal+numGlobalFeatures,rowGlobalInput);
     if(numMetaFeatures > 0) {
       testAssert(rowMeta != NULL);
       testAssert(hasRowMeta);
+      float* rowMetaInput = inputBuffers->metaInputs.get() + inputBuffers->singleInputMetaElts * nIdx;
       std::copy(rowMeta,rowMeta+numMetaFeatures,rowMetaInput);
     }
     else {
@@ -2229,28 +2326,32 @@ void NeuralNet::getOutput(
   const int numPolicyChannels = inputBuffers->singlePolicyPassResultElts;
   assert(inputBuffers->singlePolicyResultElts == numPolicyChannels * nnXLen * nnYLen);
 
-  // Transfers from host memory to device memory are asynchronous with respect to the host
+  // InputBuffers uses pinned host allocations, so all transfers can remain asynchronous on this
+  // NN server thread's CUDA stream. Queue all output copies before one synchronization below.
   CUDA_ERR(
     "getOutput",
     cudaMemcpyAsync(
       gpuHandle->getBuffer("InputMask"),
       inputBuffers->maskInputs.get(),
       inputBuffers->singleMaskBytes * batchSize,
-      cudaMemcpyHostToDevice));
+      cudaMemcpyHostToDevice,
+      cudaStreamPerThread));
   CUDA_ERR(
     "getOutput",
     cudaMemcpyAsync(
       gpuHandle->getBuffer("InputSpatial"),
       inputBuffers->spatialInputs.get(),
       inputBuffers->singleInputBytes * batchSize,
-      cudaMemcpyHostToDevice));
+      cudaMemcpyHostToDevice,
+      cudaStreamPerThread));
   CUDA_ERR(
     "getOutput",
     cudaMemcpyAsync(
       gpuHandle->getBuffer("InputGlobal"),
       inputBuffers->globalInputs.get(),
       inputBuffers->singleInputGlobalBytes * batchSize,
-      cudaMemcpyHostToDevice));
+      cudaMemcpyHostToDevice,
+      cudaStreamPerThread));
   if(numMetaFeatures > 0) {
     CUDA_ERR(
       "getOutput",
@@ -2258,7 +2359,8 @@ void NeuralNet::getOutput(
         gpuHandle->getBuffer("InputMeta"),
         inputBuffers->metaInputs.get(),
         inputBuffers->singleInputMetaBytes * batchSize,
-        cudaMemcpyHostToDevice));
+        cudaMemcpyHostToDevice,
+        cudaStreamPerThread));
   }
 
   if(!gpuHandle->enqueueWithOptionalCudaGraph(batchSize))
@@ -2266,39 +2368,46 @@ void NeuralNet::getOutput(
 
   CUDA_ERR(
     "getOutput",
-    cudaMemcpy(
+    cudaMemcpyAsync(
       inputBuffers->policyPassResults.get(),
       gpuHandle->getBuffer("OutputPolicyPass"),
       inputBuffers->singlePolicyPassResultBytes * batchSize,
-      cudaMemcpyDeviceToHost));
+      cudaMemcpyDeviceToHost,
+      cudaStreamPerThread));
   CUDA_ERR(
     "getOutput",
-    cudaMemcpy(
+    cudaMemcpyAsync(
       inputBuffers->policyResults.get(),
       gpuHandle->getBuffer("OutputPolicy"),
       inputBuffers->singlePolicyResultBytes * batchSize,
-      cudaMemcpyDeviceToHost));
+      cudaMemcpyDeviceToHost,
+      cudaStreamPerThread));
   CUDA_ERR(
     "getOutput",
-    cudaMemcpy(
+    cudaMemcpyAsync(
       inputBuffers->valueResults.get(),
       gpuHandle->getBuffer("OutputValue"),
       inputBuffers->singleValueResultBytes * batchSize,
-      cudaMemcpyDeviceToHost));
+      cudaMemcpyDeviceToHost,
+      cudaStreamPerThread));
   CUDA_ERR(
     "getOutput",
-    cudaMemcpy(
+    cudaMemcpyAsync(
       inputBuffers->scoreValueResults.get(),
       gpuHandle->getBuffer("OutputScoreValue"),
       inputBuffers->singleScoreValueResultBytes * batchSize,
-      cudaMemcpyDeviceToHost));
+      cudaMemcpyDeviceToHost,
+      cudaStreamPerThread));
   CUDA_ERR(
     "getOutput",
-    cudaMemcpy(
+    cudaMemcpyAsync(
       inputBuffers->ownershipResults.get(),
       gpuHandle->getBuffer("OutputOwnership"),
       inputBuffers->singleOwnershipResultBytes * batchSize,
-      cudaMemcpyDeviceToHost));
+      cudaMemcpyDeviceToHost,
+      cudaStreamPerThread));
+
+  CUDA_ERR("getOutput", cudaStreamSynchronize(cudaStreamPerThread));
 
   gpuHandle->printDebugOutput(batchSize);
   gpuHandle->trtErrorRecorder.clear();

--- a/cpp/neuralnet/trtbackend.cpp
+++ b/cpp/neuralnet/trtbackend.cpp
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <cstdint>
 #include <fstream>
+#include <limits>
 #include <random>
 #include <set>
 
@@ -37,6 +38,14 @@ static void checkCudaError(const cudaError_t status, const char* opName, const c
 }
 #define CUDA_ERR(opName, x) \
   { checkCudaError((x), opName, __FILE__, #x, __LINE__); }
+
+struct CudaMemoryDeleter {
+  void operator()(void* ptr) const noexcept {
+    if(ptr != nullptr)
+      cudaFree(ptr);
+  }
+};
+using CudaMemory = unique_ptr<void, CudaMemoryDeleter>;
 
 // Write `data` to `path` atomically, so a reader either sees the complete
 // old file or the complete new one, never a torn/truncated write from a crash or a racing process.
@@ -80,6 +89,8 @@ struct ComputeContext {
   string homeDataDirOverride;
   bool useOnnx;          // build via the ONNX emitter (default true); false = hand-built ModelParser
   bool transformerNHWC;  // ONNX emitter: run transformer blocks channel-last (default true)
+  bool useCudaGraph;
+  int cudaGraphMaxBatchSize;
   string dumpDebugPlanToDir;  // if non-empty, dump emitted ONNX + built-engine layer info here (debug)
 };
 
@@ -110,6 +121,12 @@ ComputeContext* NeuralNet::createComputeContext(
   // KataGo runs at, and it's the simpler graph. trtTransformerNHWC=true opts into the NHWC path (whole
   // trunk channel-last with NCHW<->NHWC conversions around it), which wins on single-stream latency.
   context->transformerNHWC = cfg.contains("trtTransformerNHWC") ? cfg.getBool("trtTransformerNHWC") : false;
+  // CUDA Graphs reduce CPU launch overhead, but each captured batch size needs a persistent TensorRT
+  // execution context per NN server thread. Keep this opt-in and cap the default cache so memory use
+  // remains predictable.
+  context->useCudaGraph = cfg.contains("trtUseCudaGraph") ? cfg.getBool("trtUseCudaGraph") : false;
+  context->cudaGraphMaxBatchSize =
+    cfg.contains("trtCudaGraphMaxBatchSize") ? cfg.getInt("trtCudaGraphMaxBatchSize", 1, 65536) : 16;
   // Debugging: if set, the ONNX-emitter path dumps the emitted ONNX model and the built engine's
   // per-layer info (precision/format/tactic, via a detailed-profiling build + IEngineInspector) into
   // this directory. Files are disambiguated by board size, FP16/FP32, and exact/max NN-length so the
@@ -1136,7 +1153,26 @@ struct TRTErrorRecorder : IErrorRecorder {
 
 
 struct ComputeHandle {
+  struct CudaGraphEntry {
+    unique_ptr<IExecutionContext> exec;
+    cudaGraphExec_t graphExec;
+
+    explicit CudaGraphEntry(unique_ptr<IExecutionContext>&& exec_)
+      : exec(std::move(exec_)), graphExec(nullptr) {}
+
+    ~CudaGraphEntry() noexcept {
+      // Captured nodes retain launch state owned by the TensorRT execution context.
+      if(graphExec != nullptr)
+        cudaGraphExecDestroy(graphExec);
+    }
+
+    CudaGraphEntry() = delete;
+    CudaGraphEntry(const CudaGraphEntry&) = delete;
+    CudaGraphEntry& operator=(const CudaGraphEntry&) = delete;
+  };
+
   ComputeContext* ctx;
+  Logger* externalLogger;
 
   bool usingFP16;
   int maxBatchSize;
@@ -1145,10 +1181,15 @@ struct ComputeHandle {
 
   TRTLogger trtLogger;
   TRTErrorRecorder trtErrorRecorder;
-  map<string, void*> buffers;
   unique_ptr<IRuntime> runtime;
   unique_ptr<ICudaEngine> engine;
+  CudaMemory executionDeviceMemory;
+  size_t executionDeviceMemoryBytes;
+  map<string, CudaMemory> buffers;
   unique_ptr<IExecutionContext> exec;
+  bool cudaGraphsEnabled;
+  int graphMaxBatchSize;
+  map<int, unique_ptr<CudaGraphEntry>> cudaGraphs;
 
   ComputeHandle(
     Logger* logger,
@@ -1158,8 +1199,22 @@ struct ComputeHandle {
     int maxBatchSz,
     bool requireExactNNLen) {
     ctx = context;
+    externalLogger = logger;
+    executionDeviceMemoryBytes = 0;
+    cudaGraphsEnabled = ctx->useCudaGraph;
+
+#if NV_TENSORRT_MAJOR == 8 && NV_TENSORRT_MINOR < 6
+    if(cudaGraphsEnabled) {
+      cudaGraphsEnabled = false;
+      if(externalLogger != nullptr) {
+        externalLogger->write(
+          "TensorRT backend: trtUseCudaGraph requires TensorRT 8.6 or newer; using enqueueV3");
+      }
+    }
+#endif
 
     maxBatchSize = maxBatchSz;
+    graphMaxBatchSize = std::min(maxBatchSize, ctx->cudaGraphMaxBatchSize);
     modelVersion = loadedModel->modelDesc.modelVersion;
 
     // Certain minor versions of TensorRT uses a global logger, which is bad.
@@ -1321,6 +1376,17 @@ struct ComputeHandle {
     debugOutputs = model->debugOutputs;
     config->addOptimizationProfile(profile);
 
+#if (NV_TENSORRT_MAJOR == 8 && NV_TENSORRT_MINOR >= 6) || NV_TENSORRT_MAJOR == 9
+    // TensorRT 8.6 and 9 require this preview feature before multiple execution contexts may
+    // share optimization profile 0. Profile sharing became the default behavior in TensorRT 10.
+    if(cudaGraphsEnabled) {
+      config->setPreviewFeature(PreviewFeature::kPROFILE_SHARING_0806, true);
+      if(!config->getPreviewFeature(PreviewFeature::kPROFILE_SHARING_0806)) {
+        throw StringError("TensorRT backend: failed to enable optimization-profile sharing");
+      }
+    }
+#endif
+
     // Honor per-layer precision constraints. The ONNX path pins some layers to FP32 and needs a hard
     // constraint (kOBEY) so TensorRT cannot fall back to FP16; the ModelParser path uses kPREFER.
     config->setFlag(forceObeyPrecision ? BuilderFlag::kOBEY_PRECISION_CONSTRAINTS : BuilderFlag::kPREFER_PRECISION_CONSTRAINTS);
@@ -1379,10 +1445,18 @@ struct ComputeHandle {
       // every knob that changes the built engine: lib/device/salt, board+batch+precision, and the
       // backend build mode (ONNX vs ModelParser, and NHWC vs NCHW for the ONNX path). The
       // build-mode tag is folded into both the filename (for human readability) and paramStr.
+      string cudaGraphBuildModeStr;
+#if (NV_TENSORRT_MAJOR == 8 && NV_TENSORRT_MINOR >= 6) || NV_TENSORRT_MAJOR == 9
+      // Only TensorRT 8.6 and 9 change the serialized engine when CUDA Graphs are enabled:
+      // TensorRT 10+ shares profiles by default, while 8.5 cannot use this path.
+      if(cudaGraphsEnabled)
+        cudaGraphBuildModeStr = "cg";
+#endif
       string buildModeStr = Global::strprintf(
-        "%s%s",
+        "%s%s%s",
         ctx->useOnnx ? "onnx" : "prsr",
-        (ctx->useOnnx && ctx->transformerNHWC) ? "nh" : "");
+        (ctx->useOnnx && ctx->transformerNHWC) ? "nh" : "",
+        cudaGraphBuildModeStr.c_str());
       const char* lenStr = requireExactNNLen ? "ex" : "mx";
       auto planCacheFile = Global::strprintf(
         "%s/trt-%d_gpu-%s_net-%s_s%d_%s_%s%dx%d_b%d_fp%d",
@@ -1541,7 +1615,35 @@ struct ComputeHandle {
     if(!engine) {
       throw StringError("TensorRT backend: failed to create cuda engine");
     }
-    exec.reset(engine->createExecutionContext());
+
+    if(cudaGraphsEnabled) {
+#if NV_TENSORRT_MAJOR > 10 || (NV_TENSORRT_MAJOR == 10 && NV_TENSORRT_MINOR >= 1)
+      const int64_t requiredMemory = engine->getDeviceMemorySizeV2();
+      if(requiredMemory < 0 ||
+         static_cast<uint64_t>(requiredMemory) > numeric_limits<size_t>::max()) {
+        throw StringError("TensorRT backend: invalid execution-context device-memory size");
+      }
+      executionDeviceMemoryBytes = static_cast<size_t>(requiredMemory);
+#else
+      executionDeviceMemoryBytes = engine->getDeviceMemorySize();
+#endif
+      if(executionDeviceMemoryBytes > 0) {
+        void* memory = nullptr;
+        CUDA_ERR("ComputeHandle", cudaMalloc(&memory, executionDeviceMemoryBytes));
+        executionDeviceMemory.reset(memory);
+      }
+
+#if NV_TENSORRT_MAJOR >= 10
+      exec.reset(engine->createExecutionContext(ExecutionContextAllocationStrategy::kUSER_MANAGED));
+#else
+      exec.reset(engine->createExecutionContextWithoutDeviceMemory());
+#endif
+      if(exec != nullptr)
+        setExecutionDeviceMemory(exec.get());
+    }
+    else {
+      exec.reset(engine->createExecutionContext());
+    }
     if(!exec) {
       throw StringError("TensorRT backend: failed to create execution context");
     }
@@ -1565,24 +1667,54 @@ struct ComputeHandle {
 
     for(int i = 0; i < engine->getNbIOTensors(); i++) {
       void* buffer = nullptr;
-      auto name = engine->getIOTensorName(i);
+      const char* name = engine->getIOTensorName(i);
       auto dims = engine->getTensorShape(name);
       size_t bytes = accumulate(dims.d + 1, dims.d + dims.nbDims, maxBatchSize * sizeof(float), multiplies<size_t>());
       CUDA_ERR("ComputeHandle", cudaMalloc(&buffer, bytes));
-      buffers.emplace(make_pair(name, buffer));
-      exec->setTensorAddress(name, buffer);
+      auto inserted = buffers.emplace(name, CudaMemory(buffer));
+      if(!inserted.second)
+        throw StringError("TensorRT backend: duplicate I/O tensor name " + string(name));
+      if(!exec->setTensorAddress(name, inserted.first->second.get()))
+        throw StringError("TensorRT backend: failed to bind I/O tensor " + string(name));
     }
 
-    exec->setOptimizationProfileAsync(0, cudaStreamPerThread);
-    cudaStreamSynchronize(cudaStreamPerThread);
+    if(!exec->setOptimizationProfileAsync(0, cudaStreamPerThread))
+      throw StringError("TensorRT backend: failed to select optimization profile");
+    CUDA_ERR("ComputeHandle", cudaStreamSynchronize(cudaStreamPerThread));
+
+    if(cudaGraphsEnabled) {
+      // Each capture first runs a shape-flush inference. Initialize the full input allocations so
+      // prewarming never reads uninitialized device memory.
+      for(int i = 0; i < engine->getNbIOTensors(); i++) {
+        const char* name = engine->getIOTensorName(i);
+        if(engine->getTensorIOMode(name) == TensorIOMode::kINPUT) {
+          CUDA_ERR(
+            "ComputeHandle",
+            cudaMemsetAsync(getBuffer(name), 0, getBufferBytes(name), cudaStreamPerThread));
+        }
+      }
+      CUDA_ERR("ComputeHandle", cudaStreamSynchronize(cudaStreamPerThread));
+
+      string failureReason;
+      for(int batchSize = 1; batchSize <= graphMaxBatchSize; batchSize++) {
+        if(!captureCudaGraph(batchSize, failureReason)) {
+          disableCudaGraphs(failureReason);
+          break;
+        }
+      }
+      if(cudaGraphsEnabled && externalLogger != nullptr) {
+        externalLogger->write(Global::strprintf(
+          "TensorRT backend: prewarmed CUDA Graphs for batch sizes 1-%d "
+          "(shared execution memory %llu bytes)",
+          graphMaxBatchSize,
+          (unsigned long long)executionDeviceMemoryBytes));
+      }
+    }
+
     trtErrorRecorder.clear();
   }
 
-  ~ComputeHandle() {
-    for(auto ptr: buffers) {
-      CUDA_ERR("~ComputeHandle", cudaFree(ptr.second));
-    }
-  }
+  ~ComputeHandle() = default;
 
   ComputeHandle() = delete;
   ComputeHandle(const ComputeHandle&) = delete;
@@ -1591,7 +1723,7 @@ struct ComputeHandle {
   void* getBuffer(const char* name) {
     auto search = buffers.find(name);
     if(search != buffers.end()) {
-      return search->second;
+      return search->second.get();
     } else {
       throw StringError(Global::strprintf("ComputeHandle: unknown tensor name %s", name));
     }
@@ -1623,6 +1755,144 @@ struct ComputeHandle {
     } else {
       throw StringError(Global::strprintf("ComputeHandle: unknown tensor name %s", name));
     }
+  }
+
+  void setExecutionDeviceMemory(IExecutionContext* executionContext) {
+#if NV_TENSORRT_MAJOR > 10 || (NV_TENSORRT_MAJOR == 10 && NV_TENSORRT_MINOR >= 1)
+    executionContext->setDeviceMemoryV2(
+      executionDeviceMemory.get(), static_cast<int64_t>(executionDeviceMemoryBytes));
+#else
+    executionContext->setDeviceMemory(executionDeviceMemory.get());
+#endif
+  }
+
+  unique_ptr<IExecutionContext> createGraphExecutionContext(string& failureReason) {
+#if NV_TENSORRT_MAJOR >= 10
+    auto graphContext = unique_ptr<IExecutionContext>(
+      engine->createExecutionContext(ExecutionContextAllocationStrategy::kUSER_MANAGED));
+#else
+    auto graphContext = unique_ptr<IExecutionContext>(engine->createExecutionContextWithoutDeviceMemory());
+#endif
+    if(!graphContext) {
+      failureReason = "could not create a per-batch execution context";
+      return nullptr;
+    }
+
+    setExecutionDeviceMemory(graphContext.get());
+    for(int i = 0; i < engine->getNbIOTensors(); i++) {
+      const char* name = engine->getIOTensorName(i);
+      if(!graphContext->setTensorAddress(name, getBuffer(name))) {
+        failureReason = "could not bind I/O tensor " + string(name);
+        return nullptr;
+      }
+    }
+    if(!graphContext->setOptimizationProfileAsync(0, cudaStreamPerThread)) {
+      failureReason = "could not select optimization profile 0";
+      return nullptr;
+    }
+    CUDA_ERR("createGraphExecutionContext", cudaStreamSynchronize(cudaStreamPerThread));
+    return graphContext;
+  }
+
+  bool setInputShapes(IExecutionContext* executionContext, int batchSize) {
+    for(int i = 0; i < engine->getNbIOTensors(); i++) {
+      const char* name = engine->getIOTensorName(i);
+      if(engine->getTensorIOMode(name) == TensorIOMode::kINPUT &&
+         !executionContext->setInputShape(name, getBufferDynamicShape(name, batchSize))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool enqueueWithoutCudaGraph(int batchSize) {
+    return setInputShapes(exec.get(), batchSize) && exec->enqueueV3(cudaStreamPerThread);
+  }
+
+  void disableCudaGraphs(const string& reason) {
+    cudaGraphsEnabled = false;
+    cudaGraphs.clear();
+    if(externalLogger != nullptr) {
+      externalLogger->write(
+        "TensorRT backend: disabling CUDA Graphs and using enqueueV3: " + reason);
+    }
+  }
+
+  bool captureCudaGraph(int batchSize, string& failureReason) {
+    // A ComputeHandle is owned by one NN server thread, so these contexts execute serially and may
+    // safely share one user-managed activation allocation. TensorRT requires a distinct context for
+    // each captured dynamic shape.
+    auto graphContext = createGraphExecutionContext(failureReason);
+    if(!graphContext)
+      return false;
+    auto entry = make_unique<CudaGraphEntry>(std::move(graphContext));
+
+    if(!setInputShapes(entry->exec.get(), batchSize)) {
+      failureReason = "could not set dynamic input shapes";
+      return false;
+    }
+
+    // The first enqueue after changing a dynamic shape may perform deferred, non-capturable work.
+    if(!entry->exec->enqueueV3(cudaStreamPerThread)) {
+      throw StringError("TensorRT backend: shape-flush enqueueV3 failed");
+    }
+    CUDA_ERR("captureCudaGraph", cudaStreamSynchronize(cudaStreamPerThread));
+
+    cudaError_t status =
+      cudaStreamBeginCapture(cudaStreamPerThread, cudaStreamCaptureModeThreadLocal);
+    if(status != cudaSuccess) {
+      failureReason = string("cudaStreamBeginCapture failed: ") + cudaGetErrorString(status);
+      (void)cudaGetLastError();
+      return false;
+    }
+
+    const bool enqueueSucceeded = entry->exec->enqueueV3(cudaStreamPerThread);
+    cudaGraph_t graph = nullptr;
+    const cudaError_t endStatus = cudaStreamEndCapture(cudaStreamPerThread, &graph);
+    if(!enqueueSucceeded || endStatus != cudaSuccess || graph == nullptr) {
+      if(graph != nullptr)
+        cudaGraphDestroy(graph);
+      failureReason = !enqueueSucceeded
+        ? "enqueueV3 was not capturable"
+        : string("cudaStreamEndCapture failed: ") + cudaGetErrorString(endStatus);
+      (void)cudaGetLastError();
+      return false;
+    }
+
+#if CUDART_VERSION >= 11040
+    status = cudaGraphInstantiateWithFlags(&entry->graphExec, graph, 0);
+#else
+    status = cudaGraphInstantiate(&entry->graphExec, graph, nullptr, nullptr, 0);
+#endif
+    cudaGraphDestroy(graph);
+    if(status != cudaSuccess || entry->graphExec == nullptr) {
+      failureReason = string("cudaGraphInstantiate failed: ") + cudaGetErrorString(status);
+      (void)cudaGetLastError();
+      return false;
+    }
+
+    const auto inserted = cudaGraphs.emplace(batchSize, std::move(entry));
+    if(!inserted.second) {
+      failureReason = "duplicate per-batch CUDA Graph cache entry";
+      return false;
+    }
+    return true;
+  }
+
+  bool enqueueWithOptionalCudaGraph(int batchSize) {
+    // Requests above the cap retain the ordinary enqueueV3 path. Larger batches already amortize
+    // launch overhead well, while every captured size carries persistent TensorRT context memory.
+    if(!cudaGraphsEnabled || batchSize > graphMaxBatchSize)
+      return enqueueWithoutCudaGraph(batchSize);
+
+    auto cached = cudaGraphs.find(batchSize);
+    if(cached == cudaGraphs.end()) {
+      disableCudaGraphs("missing prewarmed graph for batch size " + Global::intToString(batchSize));
+      return enqueueWithoutCudaGraph(batchSize);
+    }
+
+    CUDA_ERR("enqueueWithOptionalCudaGraph", cudaGraphLaunch(cached->second->graphExec, cudaStreamPerThread));
+    return true;
   }
 
   // DEBUG (kept commented out): when KATAGO_TRT_DUMP_ACTS is set, dump every DBG__ output tensor (added
@@ -1991,20 +2261,8 @@ void NeuralNet::getOutput(
         cudaMemcpyHostToDevice));
   }
 
-  auto maskInputDims = gpuHandle->getBufferDynamicShape("InputMask", batchSize);
-  auto spatialInputDims = gpuHandle->getBufferDynamicShape("InputSpatial", batchSize);
-  auto globalInputDims = gpuHandle->getBufferDynamicShape("InputGlobal", batchSize);
-
-  gpuHandle->exec->setInputShape("InputMask", maskInputDims);
-  gpuHandle->exec->setInputShape("InputSpatial", spatialInputDims);
-  gpuHandle->exec->setInputShape("InputGlobal", globalInputDims);
-
-  if(numMetaFeatures > 0) {
-    auto metaInputDims = gpuHandle->getBufferDynamicShape("InputMeta", batchSize);
-    gpuHandle->exec->setInputShape("InputMeta", metaInputDims);
-  }
-
-  gpuHandle->exec->enqueueV3(cudaStreamPerThread);
+  if(!gpuHandle->enqueueWithOptionalCudaGraph(batchSize))
+    throw StringError("TensorRT backend: enqueueV3 failed");
 
   CUDA_ERR(
     "getOutput",

--- a/cpp/neuralnet/trtbackend.cpp
+++ b/cpp/neuralnet/trtbackend.cpp
@@ -1180,6 +1180,7 @@ struct SharedTRTEngine {
   TRTErrorRecorder trtErrorRecorder;
   unique_ptr<IRuntime> runtime;
   unique_ptr<ICudaEngine> engine;
+  mutex executionContextInitMutex;
   bool usingFP16;
   vector<pair<string, string>> debugOutputs;
 
@@ -1711,6 +1712,14 @@ struct ComputeHandle {
     debugOutputs = sharedEngine->debugOutputs;
     engine = sharedEngine->engine.get();
     initializeDebugDumpPath();
+
+    // TensorRT 10.16 can intermittently fail in Myelin syncStreams when two graph-enabled handles
+    // concurrently initialize contexts and prewarm CUDA Graphs on one shared engine. Serialize only
+    // that initialization; graph-free initialization and all inference remain concurrent.
+    unique_lock<mutex> executionContextInitLock(
+      sharedEngine->executionContextInitMutex, std::defer_lock);
+    if(cudaGraphsEnabled)
+      executionContextInitLock.lock();
 
     if(cudaGraphsEnabled) {
 #if NV_TENSORRT_MAJOR > 10 || (NV_TENSORRT_MAJOR == 10 && NV_TENSORRT_MINOR >= 1)

--- a/cpp/neuralnet/trtbackend.cpp
+++ b/cpp/neuralnet/trtbackend.cpp
@@ -1313,388 +1313,388 @@ struct ComputeHandle {
       TRTLogger& trtLogger = newSharedEngine->trtLogger;
       trtLogger.setLogger(logger);
 
-    const bool useOnnxEmit = ctx->useOnnx;
+      const bool useOnnxEmit = ctx->useOnnx;
 
-    auto builder = unique_ptr<IBuilder>(createInferBuilder(trtLogger));
-    if(!builder) {
-      throw StringError("TensorRT backend: failed to create builder");
-    }
-    auto config = unique_ptr<IBuilderConfig>(builder->createBuilderConfig());
-    if(!config) {
-      throw StringError("TensorRT backend: failed to create builder config");
-    }
-
-    if(builder->platformHasFastFp16()) {
-      if(ctx->useFP16Mode == enabled_t::True || ctx->useFP16Mode == enabled_t::Auto) {
-        config->setFlag(BuilderFlag::kFP16);
-        usingFP16 = true;
+      auto builder = unique_ptr<IBuilder>(createInferBuilder(trtLogger));
+      if(!builder) {
+        throw StringError("TensorRT backend: failed to create builder");
       }
-    } else if(ctx->useFP16Mode == enabled_t::True) {
-      throw StringError("CUDA device does not support useFP16=true");
-    }
-    // The ONNX path may pin specific layers to FP32 below and needs the constraint to be hard
-    // (kOBEY) so TensorRT cannot silently fall back to an FP16 path. The ModelParser path uses the
-    // softer kPREFER. We set the flag after building the network, once forceObeyPrecision is known.
-    bool forceObeyPrecision = false;
-
-    // Debug plan/engine dump (trtDumpDebugPlanToDir). Build a base path inside that dir, disambiguated
-    // by board size + precision + exact/max so the multiple engines built in one process don't collide.
-    initializeDebugDumpPath();
-
-    auto network = unique_ptr<INetworkDefinition>(
-      builder->createNetworkV2(1U << static_cast<int>(NetworkDefinitionCreationFlag::kEXPLICIT_BATCH)));
-    if(!network) {
-      throw StringError("TensorRT backend: failed to create network definition");
-    }
-    auto profile = builder->createOptimizationProfile();
-    if(!profile) {
-      throw StringError("TensorRT backend: failed to create optimization profile");
-    }
-    // Build the network by emitting ONNX from the ModelDesc and parsing it with nvonnxparser (the
-    // default; supports convnets and transformers), or via the hand-built ModelParser when
-    // trtDisableOnnx is set (convnets only). Both produce the same raw-head outputs, so downstream
-    // getOutput decoding is identical.
-    unique_ptr<TRTModel> model;
-    // These must outlive buildSerializedNetwork below: nvonnxparser::parse() does not necessarily
-    // deep-copy initializer weights, so the parsed INetworkDefinition may reference data inside
-    // onnxBytes (and the parser object) until the engine is actually built. Keeping them at this
-    // scope avoids a use-after-free that manifests as all-NaN engine outputs.
-    string onnxBytes;
-    unique_ptr<nvonnxparser::IParser> onnxParser;
-    if(useOnnxEmit) {
-      logger->write("TensorRT backend: building network via ONNX emitter");
-      const ModelDesc& desc = loadedModel->modelDesc;
-      OnnxModelBuilder::Result onnxResult = OnnxModelBuilder::build(desc, ctx->nnXLen, ctx->nnYLen, requireExactNNLen, ctx->transformerNHWC, logger);
-      onnxBytes = std::move(onnxResult.serializedModel);
-
-      if(dumpDebugPlan) {
-        string onnxPath = dumpDebugBasePath + ".onnx";
-        ofstream dumpOut;
-        FileUtils::open(dumpOut, onnxPath, ios::binary);
-        dumpOut.write(onnxBytes.data(), (std::streamsize)onnxBytes.size());
-        dumpOut.close();
-        logger->write("TensorRT backend: dumped emitted ONNX to " + onnxPath);
+      auto config = unique_ptr<IBuilderConfig>(builder->createBuilderConfig());
+      if(!config) {
+        throw StringError("TensorRT backend: failed to create builder config");
       }
 
-      onnxParser.reset(nvonnxparser::createParser(*network, trtLogger));
-      if(!onnxParser)
-        throw StringError("TensorRT backend: failed to create ONNX parser");
-      if(!onnxParser->parse(onnxBytes.data(), onnxBytes.size())) {
-        string msg = "TensorRT backend: failed to parse emitted ONNX model:";
-        for(int i = 0; i < onnxParser->getNbErrors(); i++)
-          msg += "\n  " + string(onnxParser->getError(i)->desc());
-        throw StringError(msg);
-      }
-
-      // Constrain all graph outputs to linear FP32, matching what ModelParser sets on its outputs.
-      // getOutput does a flat cudaMemcpy of each output buffer assuming linear layout, so without
-      // this the parser may leave outputs in a reformatted layout and the copy reads garbage.
-      for(int i = 0; i < network->getNbOutputs(); i++) {
-        ITensor* out = network->getOutput(i);
-        out->setType(DataType::kFLOAT);
-        out->setAllowedFormats(1U << static_cast<int>(TensorFormat::kLINEAR));
-      }
-
-      // Force the numerically-sensitive regions to FP32: every RMSNorm reduction (square->reduce->
-      // sqrt, which sums over many elements and loses too much precision in FP16) plus the trunk-tip
-      // norm and policy/value heads. The emitter records these layer names; we pin them via per-layer
-      // setPrecision + kOBEY_PRECISION_CONSTRAINTS (a hard constraint) so correctness does not depend
-      // on TensorRT declining to fuse a numerically-equivalent FP16 path back in. This matches the
-      // FP32-forcing the hand-built ModelParser path already does for its heads/gpool.
-      std::set<string> fp32Names;
-      fp32Names.insert(onnxResult.trunkTipAndHeadNodeNames.begin(), onnxResult.trunkTipAndHeadNodeNames.end());
-      fp32Names.insert(onnxResult.rmsNormNodeNames.begin(), onnxResult.rmsNormNodeNames.end());
-      int pinned = 0;
-      for(int i = 0; i < network->getNbLayers(); i++) {
-        ILayer* layer = network->getLayer(i);
-        const char* lname = layer->getName();
-        if(lname != nullptr && fp32Names.count(string(lname))) {
-          layer->setPrecision(DataType::kFLOAT);
-          for(int o = 0; o < layer->getNbOutputs(); o++)
-            layer->setOutputType(o, DataType::kFLOAT);
-          pinned++;
+      if(builder->platformHasFastFp16()) {
+        if(ctx->useFP16Mode == enabled_t::True || ctx->useFP16Mode == enabled_t::Auto) {
+          config->setFlag(BuilderFlag::kFP16);
+          usingFP16 = true;
         }
+      } else if(ctx->useFP16Mode == enabled_t::True) {
+        throw StringError("CUDA device does not support useFP16=true");
       }
-      forceObeyPrecision = true;
-      logger->write(Global::strprintf("TensorRT backend: pinned %d layers to FP32 (rmsnorm + heads)", pinned));
+      // The ONNX path may pin specific layers to FP32 below and needs the constraint to be hard
+      // (kOBEY) so TensorRT cannot silently fall back to an FP16 path. The ModelParser path uses the
+      // softer kPREFER. We set the flag after building the network, once forceObeyPrecision is known.
+      bool forceObeyPrecision = false;
 
-      // Set optimization profile dims for each input the parser created.
-      auto setProfile = [&](const char* name, Dims4 minDims, Dims4 optMaxDims) {
-        profile->setDimensions(name, OptProfileSelector::kMIN, minDims);
-        profile->setDimensions(name, OptProfileSelector::kOPT, optMaxDims);
-        profile->setDimensions(name, OptProfileSelector::kMAX, optMaxDims);
-      };
-      setProfile("InputMask", Dims4(1, 1, ctx->nnYLen, ctx->nnXLen), Dims4(maxBatchSize, 1, ctx->nnYLen, ctx->nnXLen));
-      setProfile("InputSpatial", Dims4(1, desc.numInputChannels, ctx->nnYLen, ctx->nnXLen), Dims4(maxBatchSize, desc.numInputChannels, ctx->nnYLen, ctx->nnXLen));
-      setProfile("InputGlobal", Dims4(1, desc.numInputGlobalChannels, 1, 1), Dims4(maxBatchSize, desc.numInputGlobalChannels, 1, 1));
+      // Debug plan/engine dump (trtDumpDebugPlanToDir). Build a base path inside that dir, disambiguated
+      // by board size + precision + exact/max so the multiple engines built in one process don't collide.
+      initializeDebugDumpPath();
 
-      model = make_unique<TRTModel>();
-      model->nnXLen = ctx->nnXLen;
-      model->nnYLen = ctx->nnYLen;
-      model->profile = profile;
-      model->network = move(network);
-      model->rawModel = loadedModel;
-      model->maxBatchSize = maxBatchSize;
-      model->requireExactNNLen = requireExactNNLen;
-      model->modelVersion = desc.modelVersion;
-      // tuneHash buckets the timing cache. This is the ONNX path's descriptor: the "onnxsalt" prefix
-      // already separates it from the ModelParser path (which builds its own "salt"-prefixed tuneDesc),
-      // and the "nhwc" field distinguishes the NHWC vs NCHW trunk layout (different layer signatures),
-      // so the two layouts don't share a timing-cache file full of mutual misses.
-      string tuneDesc = Global::strprintf(
-        "\"onnxsalt\"(%d)\"nhwc\"(%d)\"model\"(%d,%d,%d)",
-        ModelParser::tuneSalt, ctx->transformerNHWC ? 1 : 0,
-        desc.modelVersion, desc.numInputChannels, desc.numInputGlobalChannels);
-      SHA2::get256(tuneDesc.c_str(), model->tuneHash);
-    }
-    else {
-      auto modelParser = make_unique<ModelParser>();
-      model = modelParser->build(
-        move(network), profile, loadedModel, ctx->nnXLen, ctx->nnYLen, maxBatchSize, requireExactNNLen);
-    }
-    debugOutputs = model->debugOutputs;
-    config->addOptimizationProfile(profile);
-
-#if (NV_TENSORRT_MAJOR == 8 && NV_TENSORRT_MINOR >= 6) || NV_TENSORRT_MAJOR == 9
-    // TensorRT 8.6 and 9 require this preview feature before multiple execution contexts may
-    // share optimization profile 0. Profile sharing became the default behavior in TensorRT 10.
-    if(cudaGraphsEnabled) {
-      config->setPreviewFeature(PreviewFeature::kPROFILE_SHARING_0806, true);
-      if(!config->getPreviewFeature(PreviewFeature::kPROFILE_SHARING_0806)) {
-        throw StringError("TensorRT backend: failed to enable optimization-profile sharing");
+      auto network = unique_ptr<INetworkDefinition>(
+        builder->createNetworkV2(1U << static_cast<int>(NetworkDefinitionCreationFlag::kEXPLICIT_BATCH)));
+      if(!network) {
+        throw StringError("TensorRT backend: failed to create network definition");
       }
-    }
-#endif
-
-    // Honor per-layer precision constraints. The ONNX path pins some layers to FP32 and needs a hard
-    // constraint (kOBEY) so TensorRT cannot fall back to FP16; the ModelParser path uses kPREFER.
-    config->setFlag(forceObeyPrecision ? BuilderFlag::kOBEY_PRECISION_CONSTRAINTS : BuilderFlag::kPREFER_PRECISION_CONSTRAINTS);
-
-#if NV_TENSORRT_MAJOR == 8 && NV_TENSORRT_MINOR == 5
-    // This is to avoid external tactic sources and tactics that have shape switching overhead
-    if(prop->major < 8) {
-      config->setTacticSources(
-        1U << static_cast<uint32_t>(TacticSource::kJIT_CONVOLUTIONS) |
-        1U << static_cast<uint32_t>(TacticSource::kEDGE_MASK_CONVOLUTIONS));
-    } else {
-      config->setTacticSources(1U << static_cast<uint32_t>(TacticSource::kJIT_CONVOLUTIONS));
-    }
-#else
-    if(prop->major >= 8) {
-      // This is to avoid tactics that have shape switching overhead
-      config->setTacticSources(1U << static_cast<uint32_t>(TacticSource::kJIT_CONVOLUTIONS));
-      config->setBuilderOptimizationLevel(2);
-    }
-#endif
-
-    // For the debug plan dump, build with detailed profiling so the engine inspector can report
-    // per-layer precision/format/tactic (see the inspector dump after deserialize).
-    if(dumpDebugPlan)
-      config->setProfilingVerbosity(ProfilingVerbosity::kDETAILED);
-
-    // So that there are no concurrent kernel executions probably from other parts of code while profiling
-    // See CUDA Runtime API document for more details related to NULL stream and synchronization behaviors
-    config->setProfileStream(cudaStreamLegacy);
-
-    // Typical runtime allocation is much less than the 1 GiB specified below
-    config->setMemoryPoolLimit(MemoryPoolType::kWORKSPACE, 1U << 30);
-
-    string plan;
-    {
-      static mutex tuneMutex;
-      tuneMutex.lock();
-
-      auto cacheDir = HomeData::getHomeDataDir(true, ctx->homeDataDirOverride);
-      cacheDir += "/trtcache";
-      MakeDir::make(cacheDir);
-
-      uint8_t deviceHash[32];
-      SHA2::get256(prop->name, deviceHash);
-
-      // Truncated to 4 bytes
-      char deviceIdent[4 * 2 + 1];
-      for(int i = 0; i < 4; i++) {
-        sprintf(deviceIdent + i * 2, "%02x", static_cast<unsigned char>(deviceHash[i]));
+      auto profile = builder->createOptimizationProfile();
+      if(!profile) {
+        throw StringError("TensorRT backend: failed to create optimization profile");
       }
-      deviceIdent[sizeof(deviceIdent) - 1] = 0;
+      // Build the network by emitting ONNX from the ModelDesc and parsing it with nvonnxparser (the
+      // default; supports convnets and transformers), or via the hand-built ModelParser when
+      // trtDisableOnnx is set (convnets only). Both produce the same raw-head outputs, so downstream
+      // getOutput decoding is identical.
+      unique_ptr<TRTModel> model;
+      // These must outlive buildSerializedNetwork below: nvonnxparser::parse() does not necessarily
+      // deep-copy initializer weights, so the parsed INetworkDefinition may reference data inside
+      // onnxBytes (and the parser object) until the engine is actually built. Keeping them at this
+      // scope avoids a use-after-free that manifests as all-NaN engine outputs.
+      string onnxBytes;
+      unique_ptr<nvonnxparser::IParser> onnxParser;
+      if(useOnnxEmit) {
+        logger->write("TensorRT backend: building network via ONNX emitter");
+        const ModelDesc& desc = loadedModel->modelDesc;
+        OnnxModelBuilder::Result onnxResult = OnnxModelBuilder::build(desc, ctx->nnXLen, ctx->nnYLen, requireExactNNLen, ctx->transformerNHWC, logger);
+        onnxBytes = std::move(onnxResult.serializedModel);
 
-#ifdef CACHE_TENSORRT_PLAN
-      // The plan cache stores a fully serialized engine, reused only when the model SHA256 (appended
-      // to the blob and verified on read) AND paramStr both match. paramStr must therefore encode
-      // every knob that changes the built engine: lib/device/salt, board+batch+precision, and the
-      // backend build mode (ONNX vs ModelParser, and NHWC vs NCHW for the ONNX path). The
-      // build-mode tag is folded into both the filename (for human readability) and paramStr.
-      string cudaGraphBuildModeStr;
-#if (NV_TENSORRT_MAJOR == 8 && NV_TENSORRT_MINOR >= 6) || NV_TENSORRT_MAJOR == 9
-      // Only TensorRT 8.6 and 9 change the serialized engine when CUDA Graphs are enabled:
-      // TensorRT 10+ shares profiles by default, while 8.5 cannot use this path.
-      if(cudaGraphsEnabled)
-        cudaGraphBuildModeStr = "cg";
-#endif
-      string buildModeStr = Global::strprintf(
-        "%s%s%s",
-        ctx->useOnnx ? "onnx" : "prsr",
-        (ctx->useOnnx && ctx->transformerNHWC) ? "nh" : "",
-        cudaGraphBuildModeStr.c_str());
-      const char* lenStr = requireExactNNLen ? "ex" : "mx";
-      auto planCacheFile = Global::strprintf(
-        "%s/trt-%d_gpu-%s_net-%s_s%d_%s_%s%dx%d_b%d_fp%d",
-        cacheDir.c_str(),
-        getInferLibVersion(),
-        deviceIdent,
-        loadedModel->modelDesc.name.c_str(),
-        ModelParser::tuneSalt,
-        buildModeStr.c_str(),
-        lenStr,
-        ctx->nnYLen,
-        ctx->nnXLen,
-        maxBatchSize,
-        usingFP16 ? 16 : 32);
-      string paramStr = Global::strprintf(
-        "_%d_%s_s%d_%s_%s_%d_%d_%d_%d",
-        getInferLibVersion(),
-        deviceIdent,
-        ModelParser::tuneSalt,
-        buildModeStr.c_str(),
-        lenStr,
-        ctx->nnYLen,
-        ctx->nnXLen,
-        maxBatchSize,
-        usingFP16 ? 16 : 32);
-      try {
-        plan = FileUtils::readFileBinary(planCacheFile);
-      } catch(const StringError& e) {
-        (void)e;
-      };
+        if(dumpDebugPlan) {
+          string onnxPath = dumpDebugBasePath + ".onnx";
+          ofstream dumpOut;
+          FileUtils::open(dumpOut, onnxPath, ios::binary);
+          dumpOut.write(onnxBytes.data(), (std::streamsize)onnxBytes.size());
+          dumpOut.close();
+          logger->write("TensorRT backend: dumped emitted ONNX to " + onnxPath);
+        }
 
-      if(plan.size() > 0) {
-        if(plan.size() < 64 + paramStr.size()) {
-          logger->write("Could not parse plan, unexpected size in " + planCacheFile);
-          plan.clear();
-        } else {
-          string cachedParamStr = plan.substr(plan.size() - paramStr.size());
-          string modelHash = plan.substr(plan.size() - 64 - paramStr.size(), 64);
-          if(modelHash != loadedModel->modelDesc.sha256) {
-            logger->write("Plan cache is corrupted or is for the wrong model in " + planCacheFile);
-            plan.clear();
-          } else if(cachedParamStr != paramStr) {
-            logger->write("Plan cache is corrupted or is for the wrong parameters in " + planCacheFile);
-            plan.clear();
-          } else {
-            plan.erase(plan.size() - 64 - paramStr.size());
+        onnxParser.reset(nvonnxparser::createParser(*network, trtLogger));
+        if(!onnxParser)
+          throw StringError("TensorRT backend: failed to create ONNX parser");
+        if(!onnxParser->parse(onnxBytes.data(), onnxBytes.size())) {
+          string msg = "TensorRT backend: failed to parse emitted ONNX model:";
+          for(int i = 0; i < onnxParser->getNbErrors(); i++)
+            msg += "\n  " + string(onnxParser->getError(i)->desc());
+          throw StringError(msg);
+        }
+
+        // Constrain all graph outputs to linear FP32, matching what ModelParser sets on its outputs.
+        // getOutput does a flat cudaMemcpy of each output buffer assuming linear layout, so without
+        // this the parser may leave outputs in a reformatted layout and the copy reads garbage.
+        for(int i = 0; i < network->getNbOutputs(); i++) {
+          ITensor* out = network->getOutput(i);
+          out->setType(DataType::kFLOAT);
+          out->setAllowedFormats(1U << static_cast<int>(TensorFormat::kLINEAR));
+        }
+
+        // Force the numerically-sensitive regions to FP32: every RMSNorm reduction (square->reduce->
+        // sqrt, which sums over many elements and loses too much precision in FP16) plus the trunk-tip
+        // norm and policy/value heads. The emitter records these layer names; we pin them via per-layer
+        // setPrecision + kOBEY_PRECISION_CONSTRAINTS (a hard constraint) so correctness does not depend
+        // on TensorRT declining to fuse a numerically-equivalent FP16 path back in. This matches the
+        // FP32-forcing the hand-built ModelParser path already does for its heads/gpool.
+        std::set<string> fp32Names;
+        fp32Names.insert(onnxResult.trunkTipAndHeadNodeNames.begin(), onnxResult.trunkTipAndHeadNodeNames.end());
+        fp32Names.insert(onnxResult.rmsNormNodeNames.begin(), onnxResult.rmsNormNodeNames.end());
+        int pinned = 0;
+        for(int i = 0; i < network->getNbLayers(); i++) {
+          ILayer* layer = network->getLayer(i);
+          const char* lname = layer->getName();
+          if(lname != nullptr && fp32Names.count(string(lname))) {
+            layer->setPrecision(DataType::kFLOAT);
+            for(int o = 0; o < layer->getNbOutputs(); o++)
+              layer->setOutputType(o, DataType::kFLOAT);
+            pinned++;
           }
         }
-      }
+        forceObeyPrecision = true;
+        logger->write(Global::strprintf("TensorRT backend: pinned %d layers to FP32 (rmsnorm + heads)", pinned));
 
-      if(plan.size() <= 0) {
-        logger->write("Creating new plan cache");
-        auto planBuffer = unique_ptr<IHostMemory>(builder->buildSerializedNetwork(*model->network, *config));
-        if(!planBuffer) {
-          throw StringError("TensorRT backend: failed to create plan");
+        // Set optimization profile dims for each input the parser created.
+        auto setProfile = [&](const char* name, Dims4 minDims, Dims4 optMaxDims) {
+          profile->setDimensions(name, OptProfileSelector::kMIN, minDims);
+          profile->setDimensions(name, OptProfileSelector::kOPT, optMaxDims);
+          profile->setDimensions(name, OptProfileSelector::kMAX, optMaxDims);
+        };
+        setProfile("InputMask", Dims4(1, 1, ctx->nnYLen, ctx->nnXLen), Dims4(maxBatchSize, 1, ctx->nnYLen, ctx->nnXLen));
+        setProfile("InputSpatial", Dims4(1, desc.numInputChannels, ctx->nnYLen, ctx->nnXLen), Dims4(maxBatchSize, desc.numInputChannels, ctx->nnYLen, ctx->nnXLen));
+        setProfile("InputGlobal", Dims4(1, desc.numInputGlobalChannels, 1, 1), Dims4(maxBatchSize, desc.numInputGlobalChannels, 1, 1));
+
+        model = make_unique<TRTModel>();
+        model->nnXLen = ctx->nnXLen;
+        model->nnYLen = ctx->nnYLen;
+        model->profile = profile;
+        model->network = move(network);
+        model->rawModel = loadedModel;
+        model->maxBatchSize = maxBatchSize;
+        model->requireExactNNLen = requireExactNNLen;
+        model->modelVersion = desc.modelVersion;
+        // tuneHash buckets the timing cache. This is the ONNX path's descriptor: the "onnxsalt" prefix
+        // already separates it from the ModelParser path (which builds its own "salt"-prefixed tuneDesc),
+        // and the "nhwc" field distinguishes the NHWC vs NCHW trunk layout (different layer signatures),
+        // so the two layouts don't share a timing-cache file full of mutual misses.
+        string tuneDesc = Global::strprintf(
+          "\"onnxsalt\"(%d)\"nhwc\"(%d)\"model\"(%d,%d,%d)",
+          ModelParser::tuneSalt, ctx->transformerNHWC ? 1 : 0,
+          desc.modelVersion, desc.numInputChannels, desc.numInputGlobalChannels);
+        SHA2::get256(tuneDesc.c_str(), model->tuneHash);
+      }
+      else {
+        auto modelParser = make_unique<ModelParser>();
+        model = modelParser->build(
+          move(network), profile, loadedModel, ctx->nnXLen, ctx->nnYLen, maxBatchSize, requireExactNNLen);
+      }
+      debugOutputs = model->debugOutputs;
+      config->addOptimizationProfile(profile);
+
+#if (NV_TENSORRT_MAJOR == 8 && NV_TENSORRT_MINOR >= 6) || NV_TENSORRT_MAJOR == 9
+      // TensorRT 8.6 and 9 require this preview feature before multiple execution contexts may
+      // share optimization profile 0. Profile sharing became the default behavior in TensorRT 10.
+      if(cudaGraphsEnabled) {
+        config->setPreviewFeature(PreviewFeature::kPROFILE_SHARING_0806, true);
+        if(!config->getPreviewFeature(PreviewFeature::kPROFILE_SHARING_0806)) {
+          throw StringError("TensorRT backend: failed to enable optimization-profile sharing");
+        }
+      }
+#endif
+
+      // Honor per-layer precision constraints. The ONNX path pins some layers to FP32 and needs a hard
+      // constraint (kOBEY) so TensorRT cannot fall back to FP16; the ModelParser path uses kPREFER.
+      config->setFlag(forceObeyPrecision ? BuilderFlag::kOBEY_PRECISION_CONSTRAINTS : BuilderFlag::kPREFER_PRECISION_CONSTRAINTS);
+
+#if NV_TENSORRT_MAJOR == 8 && NV_TENSORRT_MINOR == 5
+      // This is to avoid external tactic sources and tactics that have shape switching overhead
+      if(prop->major < 8) {
+        config->setTacticSources(
+          1U << static_cast<uint32_t>(TacticSource::kJIT_CONVOLUTIONS) |
+          1U << static_cast<uint32_t>(TacticSource::kEDGE_MASK_CONVOLUTIONS));
+      } else {
+        config->setTacticSources(1U << static_cast<uint32_t>(TacticSource::kJIT_CONVOLUTIONS));
+      }
+#else
+      if(prop->major >= 8) {
+        // This is to avoid tactics that have shape switching overhead
+        config->setTacticSources(1U << static_cast<uint32_t>(TacticSource::kJIT_CONVOLUTIONS));
+        config->setBuilderOptimizationLevel(2);
+      }
+#endif
+
+      // For the debug plan dump, build with detailed profiling so the engine inspector can report
+      // per-layer precision/format/tactic (see the inspector dump after deserialize).
+      if(dumpDebugPlan)
+        config->setProfilingVerbosity(ProfilingVerbosity::kDETAILED);
+
+      // So that there are no concurrent kernel executions probably from other parts of code while profiling
+      // See CUDA Runtime API document for more details related to NULL stream and synchronization behaviors
+      config->setProfileStream(cudaStreamLegacy);
+
+      // Typical runtime allocation is much less than the 1 GiB specified below
+      config->setMemoryPoolLimit(MemoryPoolType::kWORKSPACE, 1U << 30);
+
+      string plan;
+      {
+        static mutex tuneMutex;
+        tuneMutex.lock();
+
+        auto cacheDir = HomeData::getHomeDataDir(true, ctx->homeDataDirOverride);
+        cacheDir += "/trtcache";
+        MakeDir::make(cacheDir);
+
+        uint8_t deviceHash[32];
+        SHA2::get256(prop->name, deviceHash);
+
+        // Truncated to 4 bytes
+        char deviceIdent[4 * 2 + 1];
+        for(int i = 0; i < 4; i++) {
+          sprintf(deviceIdent + i * 2, "%02x", static_cast<unsigned char>(deviceHash[i]));
+        }
+        deviceIdent[sizeof(deviceIdent) - 1] = 0;
+
+#ifdef CACHE_TENSORRT_PLAN
+        // The plan cache stores a fully serialized engine, reused only when the model SHA256 (appended
+        // to the blob and verified on read) AND paramStr both match. paramStr must therefore encode
+        // every knob that changes the built engine: lib/device/salt, board+batch+precision, and the
+        // backend build mode (ONNX vs ModelParser, and NHWC vs NCHW for the ONNX path). The
+        // build-mode tag is folded into both the filename (for human readability) and paramStr.
+        string cudaGraphBuildModeStr;
+#if (NV_TENSORRT_MAJOR == 8 && NV_TENSORRT_MINOR >= 6) || NV_TENSORRT_MAJOR == 9
+        // Only TensorRT 8.6 and 9 change the serialized engine when CUDA Graphs are enabled:
+        // TensorRT 10+ shares profiles by default, while 8.5 cannot use this path.
+        if(cudaGraphsEnabled)
+          cudaGraphBuildModeStr = "cg";
+#endif
+        string buildModeStr = Global::strprintf(
+          "%s%s%s",
+          ctx->useOnnx ? "onnx" : "prsr",
+          (ctx->useOnnx && ctx->transformerNHWC) ? "nh" : "",
+          cudaGraphBuildModeStr.c_str());
+        const char* lenStr = requireExactNNLen ? "ex" : "mx";
+        auto planCacheFile = Global::strprintf(
+          "%s/trt-%d_gpu-%s_net-%s_s%d_%s_%s%dx%d_b%d_fp%d",
+          cacheDir.c_str(),
+          getInferLibVersion(),
+          deviceIdent,
+          loadedModel->modelDesc.name.c_str(),
+          ModelParser::tuneSalt,
+          buildModeStr.c_str(),
+          lenStr,
+          ctx->nnYLen,
+          ctx->nnXLen,
+          maxBatchSize,
+          usingFP16 ? 16 : 32);
+        string paramStr = Global::strprintf(
+          "_%d_%s_s%d_%s_%s_%d_%d_%d_%d",
+          getInferLibVersion(),
+          deviceIdent,
+          ModelParser::tuneSalt,
+          buildModeStr.c_str(),
+          lenStr,
+          ctx->nnYLen,
+          ctx->nnXLen,
+          maxBatchSize,
+          usingFP16 ? 16 : 32);
+        try {
+          plan = FileUtils::readFileBinary(planCacheFile);
+        } catch(const StringError& e) {
+          (void)e;
+        };
+
+        if(plan.size() > 0) {
+          if(plan.size() < 64 + paramStr.size()) {
+            logger->write("Could not parse plan, unexpected size in " + planCacheFile);
+            plan.clear();
+          } else {
+            string cachedParamStr = plan.substr(plan.size() - paramStr.size());
+            string modelHash = plan.substr(plan.size() - 64 - paramStr.size(), 64);
+            if(modelHash != loadedModel->modelDesc.sha256) {
+              logger->write("Plan cache is corrupted or is for the wrong model in " + planCacheFile);
+              plan.clear();
+            } else if(cachedParamStr != paramStr) {
+              logger->write("Plan cache is corrupted or is for the wrong parameters in " + planCacheFile);
+              plan.clear();
+            } else {
+              plan.erase(plan.size() - 64 - paramStr.size());
+            }
+          }
+        }
+
+        if(plan.size() <= 0) {
+          logger->write("Creating new plan cache");
+          auto planBuffer = unique_ptr<IHostMemory>(builder->buildSerializedNetwork(*model->network, *config));
+          if(!planBuffer) {
+            throw StringError("TensorRT backend: failed to create plan");
+          }
+          plan.insert(
+            plan.end(),
+            static_cast<char*>(planBuffer->data()),
+            static_cast<char*>(planBuffer->data()) + planBuffer->size());
+          if(loadedModel->modelDesc.sha256.size() != 64) {
+            throw StringError("Unexpected model hash size");
+          }
+          plan.insert(plan.end(), loadedModel->modelDesc.sha256.begin(), loadedModel->modelDesc.sha256.end());
+          plan.insert(plan.end(), paramStr.begin(), paramStr.end());
+          writeFileAtomically(planCacheFile, plan.data(), plan.size());
+          logger->write("Saved new plan cache to " + planCacheFile);
+          plan.erase(plan.size() - 64 - paramStr.size());
+          tuneMutex.unlock();
+        } else {
+          tuneMutex.unlock();
+          logger->write("Using existing plan cache at " + planCacheFile);
+        }
+#else
+        // Truncated to 6 bytes
+        char tuneIdent[6 * 2 + 1];
+        for(int i = 0; i < 6; i++) {
+          sprintf(tuneIdent + i * 2, "%02x", static_cast<unsigned char>(model->tuneHash[i]));
+        }
+        tuneIdent[sizeof(tuneIdent) - 1] = 0;
+
+        auto timingCacheFile = Global::strprintf(
+          "%s/trt-%d_gpu-%s_tune-%s_%s%dx%d_b%d_fp%d",
+          cacheDir.c_str(),
+          getInferLibVersion(),
+          deviceIdent,
+          tuneIdent,
+          requireExactNNLen ? "ex" : "mx",
+          ctx->nnYLen,
+          ctx->nnXLen,
+          maxBatchSize,
+          usingFP16 ? 16 : 32);
+
+        string timingCacheBlob;
+        try {
+          timingCacheBlob = FileUtils::readFileBinary(timingCacheFile);
+        } catch(const StringError& e) {
+          (void)e;
+        };
+        if(timingCacheBlob.size() > 0)
+          logger->write("Using existing timing cache at " + timingCacheFile);
+        else
+          logger->write("Creating new timing cache (usingFP16=" + Global::boolToString(usingFP16) + " " + Global::intToString(ctx->nnXLen) + "x" + Global::intToString(ctx->nnYLen) + " maxBatchSizeLimit=" + Global::intToString(maxBatchSize) + ")");
+
+        auto timingCache =
+          unique_ptr<ITimingCache>(config->createTimingCache(timingCacheBlob.data(), timingCacheBlob.size()));
+        auto invalidTimingCache = !config->setTimingCache(*timingCache, false);
+        if(invalidTimingCache) {
+          logger->write("Invalid timing cache, using new one instead");
+          timingCache.reset(config->createTimingCache(nullptr, 0));
+          config->setTimingCache(*timingCache, false);
+        }
+
+        unique_ptr<IHostMemory> planBuffer;
+        if(invalidTimingCache || !timingCacheBlob.size()) {
+          planBuffer.reset(builder->buildSerializedNetwork(*model->network, *config));
+          if(!planBuffer) {
+            throw StringError("TensorRT backend: failed to create plan");
+          }
+          auto serializedTimingCache = unique_ptr<IHostMemory>(config->getTimingCache()->serialize());
+          writeFileAtomically(
+            timingCacheFile, static_cast<char*>(serializedTimingCache->data()), serializedTimingCache->size());
+          logger->write("Saved new timing cache to " + timingCacheFile);
+          tuneMutex.unlock();
+        } else {
+          tuneMutex.unlock();
+          planBuffer.reset(builder->buildSerializedNetwork(*model->network, *config));
+          if(!planBuffer) {
+            throw StringError("TensorRT backend: failed to create plan");
+          }
         }
         plan.insert(
           plan.end(),
           static_cast<char*>(planBuffer->data()),
           static_cast<char*>(planBuffer->data()) + planBuffer->size());
-        if(loadedModel->modelDesc.sha256.size() != 64) {
-          throw StringError("Unexpected model hash size");
-        }
-        plan.insert(plan.end(), loadedModel->modelDesc.sha256.begin(), loadedModel->modelDesc.sha256.end());
-        plan.insert(plan.end(), paramStr.begin(), paramStr.end());
-        writeFileAtomically(planCacheFile, plan.data(), plan.size());
-        logger->write("Saved new plan cache to " + planCacheFile);
-        plan.erase(plan.size() - 64 - paramStr.size());
-        tuneMutex.unlock();
-      } else {
-        tuneMutex.unlock();
-        logger->write("Using existing plan cache at " + planCacheFile);
-      }
-#else
-      // Truncated to 6 bytes
-      char tuneIdent[6 * 2 + 1];
-      for(int i = 0; i < 6; i++) {
-        sprintf(tuneIdent + i * 2, "%02x", static_cast<unsigned char>(model->tuneHash[i]));
-      }
-      tuneIdent[sizeof(tuneIdent) - 1] = 0;
-
-      auto timingCacheFile = Global::strprintf(
-        "%s/trt-%d_gpu-%s_tune-%s_%s%dx%d_b%d_fp%d",
-        cacheDir.c_str(),
-        getInferLibVersion(),
-        deviceIdent,
-        tuneIdent,
-        requireExactNNLen ? "ex" : "mx",
-        ctx->nnYLen,
-        ctx->nnXLen,
-        maxBatchSize,
-        usingFP16 ? 16 : 32);
-
-      string timingCacheBlob;
-      try {
-        timingCacheBlob = FileUtils::readFileBinary(timingCacheFile);
-      } catch(const StringError& e) {
-        (void)e;
-      };
-      if(timingCacheBlob.size() > 0)
-        logger->write("Using existing timing cache at " + timingCacheFile);
-      else
-        logger->write("Creating new timing cache (usingFP16=" + Global::boolToString(usingFP16) + " " + Global::intToString(ctx->nnXLen) + "x" + Global::intToString(ctx->nnYLen) + " maxBatchSizeLimit=" + Global::intToString(maxBatchSize) + ")");
-
-      auto timingCache =
-        unique_ptr<ITimingCache>(config->createTimingCache(timingCacheBlob.data(), timingCacheBlob.size()));
-      auto invalidTimingCache = !config->setTimingCache(*timingCache, false);
-      if(invalidTimingCache) {
-        logger->write("Invalid timing cache, using new one instead");
-        timingCache.reset(config->createTimingCache(nullptr, 0));
-        config->setTimingCache(*timingCache, false);
-      }
-
-      unique_ptr<IHostMemory> planBuffer;
-      if(invalidTimingCache || !timingCacheBlob.size()) {
-        planBuffer.reset(builder->buildSerializedNetwork(*model->network, *config));
-        if(!planBuffer) {
-          throw StringError("TensorRT backend: failed to create plan");
-        }
-        auto serializedTimingCache = unique_ptr<IHostMemory>(config->getTimingCache()->serialize());
-        writeFileAtomically(
-          timingCacheFile, static_cast<char*>(serializedTimingCache->data()), serializedTimingCache->size());
-        logger->write("Saved new timing cache to " + timingCacheFile);
-        tuneMutex.unlock();
-      } else {
-        tuneMutex.unlock();
-        planBuffer.reset(builder->buildSerializedNetwork(*model->network, *config));
-        if(!planBuffer) {
-          throw StringError("TensorRT backend: failed to create plan");
-        }
-      }
-      plan.insert(
-        plan.end(),
-        static_cast<char*>(planBuffer->data()),
-        static_cast<char*>(planBuffer->data()) + planBuffer->size());
 #endif
-    }
+      }
 
-    if(dumpDebugPlan) {
-      string planPath = dumpDebugBasePath + ".plan";
-      ofstream pofs;
-      FileUtils::open(pofs, planPath, ios::out | ios::binary);
-      pofs.write(plan.data(), (std::streamsize)plan.size());
-      pofs.close();
-      logger->write("TensorRT backend: dumped serialized plan to " + planPath);
-    }
+      if(dumpDebugPlan) {
+        string planPath = dumpDebugBasePath + ".plan";
+        ofstream pofs;
+        FileUtils::open(pofs, planPath, ios::out | ios::binary);
+        pofs.write(plan.data(), (std::streamsize)plan.size());
+        pofs.close();
+        logger->write("TensorRT backend: dumped serialized plan to " + planPath);
+      }
 
-    newSharedEngine->runtime.reset(createInferRuntime(trtLogger));
-    if(!newSharedEngine->runtime) {
-      throw StringError("TensorRT backend: failed to create runtime");
-    }
-    newSharedEngine->trtErrorRecorder.setLogger(logger);
-    newSharedEngine->runtime->setErrorRecorder(&newSharedEngine->trtErrorRecorder);
+      newSharedEngine->runtime.reset(createInferRuntime(trtLogger));
+      if(!newSharedEngine->runtime) {
+        throw StringError("TensorRT backend: failed to create runtime");
+      }
+      newSharedEngine->trtErrorRecorder.setLogger(logger);
+      newSharedEngine->runtime->setErrorRecorder(&newSharedEngine->trtErrorRecorder);
 
-    newSharedEngine->engine.reset(newSharedEngine->runtime->deserializeCudaEngine(plan.data(), plan.size()));
-    if(!newSharedEngine->engine) {
-      throw StringError("TensorRT backend: failed to create cuda engine");
-    }
-    newSharedEngine->trtErrorRecorder.clear();
+      newSharedEngine->engine.reset(newSharedEngine->runtime->deserializeCudaEngine(plan.data(), plan.size()));
+      if(!newSharedEngine->engine) {
+        throw StringError("TensorRT backend: failed to create cuda engine");
+      }
+      newSharedEngine->trtErrorRecorder.clear();
 
       newSharedEngine->usingFP16 = usingFP16;
       newSharedEngine->debugOutputs = debugOutputs;

--- a/cpp/program/playutils.cpp
+++ b/cpp/program/playutils.cpp
@@ -832,7 +832,7 @@ string PlayUtils::BenchmarkResults::toString() const {
   out << "numSearchThreads = " << Global::strprintf("%2d",numThreads) << ":"
       << " " << totalPositionsSearched << " / " << totalPositions << " positions,"
       << " visits/s = " << Global::strprintf("%.2f",totalVisits / totalSeconds)
-      << " nnEvals/s = " << Global::strprintf("%.2f",numNNEvals / totalSeconds)
+      << " nnEvals/s = " << Global::strprintf("%.2f",getNNEvalsPerSecond())
       << " nnBatches/s = " << Global::strprintf("%.2f",numNNBatches / totalSeconds)
       << " avgBatchSize = " << Global::strprintf("%.2f",avgBatchSize)
       << " (" << Global::strprintf("%.1f", totalSeconds) << " secs)";
@@ -843,7 +843,7 @@ string PlayUtils::BenchmarkResults::toStringWithElo(const BenchmarkResults* base
   out << "numSearchThreads = " << Global::strprintf("%2d",numThreads) << ":"
       << " " << totalPositionsSearched << " / " << totalPositions << " positions,"
       << " visits/s = " << Global::strprintf("%.2f",totalVisits / totalSeconds)
-      << " nnEvals/s = " << Global::strprintf("%.2f",numNNEvals / totalSeconds)
+      << " nnEvals/s = " << Global::strprintf("%.2f",getNNEvalsPerSecond())
       << " nnBatches/s = " << Global::strprintf("%.2f",numNNBatches / totalSeconds)
       << " avgBatchSize = " << Global::strprintf("%.2f",avgBatchSize)
       << " (" << Global::strprintf("%.1f", totalSeconds) << " secs)";
@@ -855,6 +855,25 @@ string PlayUtils::BenchmarkResults::toStringWithElo(const BenchmarkResults* base
     out << " (EloDiff " << Global::strprintf("%+.0f",diff) << ")";
   }
   return out.str();
+}
+
+double PlayUtils::BenchmarkResults::getNNEvalsPerSecond() const {
+  return totalSeconds > 0.0 ? numNNEvals / totalSeconds : 0.0;
+}
+
+bool PlayUtils::BenchmarkResults::isBetterNNEvalsPerSecond(
+  const BenchmarkResults& candidate,
+  int candidateMaxBatchSize,
+  const BenchmarkResults& incumbent,
+  int incumbentMaxBatchSize
+) {
+  const double candidateNNEvalsPerSecond = candidate.getNNEvalsPerSecond();
+  const double incumbentNNEvalsPerSecond = incumbent.getNNEvalsPerSecond();
+  if(candidateNNEvalsPerSecond != incumbentNNEvalsPerSecond)
+    return candidateNNEvalsPerSecond > incumbentNNEvalsPerSecond;
+  if(candidateMaxBatchSize != incumbentMaxBatchSize)
+    return candidateMaxBatchSize < incumbentMaxBatchSize;
+  return candidate.numThreads < incumbent.numThreads;
 }
 
 //From some test matches by lightvector using g170

--- a/cpp/program/playutils.cpp
+++ b/cpp/program/playutils.cpp
@@ -876,6 +876,249 @@ bool PlayUtils::BenchmarkResults::isBetterNNEvalsPerSecond(
   return candidate.numThreads < incumbent.numThreads;
 }
 
+PlayUtils::BenchmarkTuneMode PlayUtils::getBenchmarkTuneMode(
+  bool autoTuneThreadsExplicitly,
+  bool threadsSpecified,
+  bool explicitBatchGridSpecified,
+  bool autoBatchSpecified,
+  bool fixedBatchSpecified,
+  bool halfBatchSpecified,
+  bool profileBudgetSpecified
+) {
+  if(fixedBatchSpecified && halfBatchSpecified)
+    throw StringError("Cannot specify both fixed batch size and use half batch size");
+  if(threadsSpecified && autoTuneThreadsExplicitly)
+    throw StringError("Cannot both automatically tune threads and specify fixed exact numbers of threads to test");
+  if(autoBatchSpecified && autoTuneThreadsExplicitly)
+    throw StringError("Cannot combine automatic max batch size tuning with -tune");
+  if(autoBatchSpecified && threadsSpecified)
+    throw StringError("Automatic max batch size tuning chooses its own thread counts; do not specify -threads");
+  if(autoBatchSpecified && explicitBatchGridSpecified)
+    throw StringError("Cannot combine automatic and explicit max batch size tuning");
+  if(autoBatchSpecified && (fixedBatchSpecified || halfBatchSpecified))
+    throw StringError("Cannot combine automatic max batch size tuning with fixed batch size or half batch size");
+  if(explicitBatchGridSpecified && autoTuneThreadsExplicitly)
+    throw StringError("Cannot combine max batch size tuning with automatic thread tuning");
+  if(explicitBatchGridSpecified && (fixedBatchSpecified || halfBatchSpecified))
+    throw StringError("Cannot combine max batch size tuning with fixed batch size or half batch size");
+  if(explicitBatchGridSpecified && !threadsSpecified)
+    throw StringError("Max batch size tuning requires an explicit list of thread counts using -threads");
+  if(profileBudgetSpecified && !autoBatchSpecified)
+    throw StringError("-tune-max-batch-profile-budget requires -tune-max-batch-size");
+
+  if(autoBatchSpecified)
+    return BENCHMARK_TUNE_AUTO_BATCH;
+  if(explicitBatchGridSpecified)
+    return BENCHMARK_TUNE_EXPLICIT_BATCH_GRID;
+  if(autoTuneThreadsExplicitly || !threadsSpecified)
+    return BENCHMARK_TUNE_AUTO_THREADS;
+  return BENCHMARK_TUNE_FIXED_THREADS;
+}
+
+static int clampAutoBatchValue(int x, int minValue, int maxValue) {
+  return std::max(minValue,std::min(maxValue,x));
+}
+
+vector<int> PlayUtils::getAutoBatchScoutThreads(int numServerThreads, int maxBatchSize) {
+  testAssert(numServerThreads > 0);
+  testAssert(maxBatchSize > 0);
+  const int maxThreads = 4096;
+  vector<int> threads;
+  auto add = [&](int value) {
+    value = clampAutoBatchValue(value,1,maxThreads);
+    if(std::find(threads.begin(),threads.end(),value) == threads.end())
+      threads.push_back(value);
+  };
+
+  // Global exponential landmarks are all measured, not narrowed by a unimodal
+  // assumption. For two server threads these include 32, 64, and 128.
+  add(8 * numServerThreads);
+  add(16 * numServerThreads);
+  add(32 * numServerThreads);
+  add(64 * numServerThreads);
+  add((numServerThreads+1) * std::min(maxBatchSize,128));
+
+  // Rounding can collapse logarithmic points for very small limits.
+  for(int candidate = 1; threads.size() < 5 && candidate <= maxThreads; candidate++) {
+    add(candidate);
+  }
+  sort(threads.begin(),threads.end());
+  return threads;
+}
+
+int PlayUtils::getAutoBatchScoutBatchSize(
+  const vector<BenchmarkResults>& results,
+  int maxBatchSize
+) {
+  testAssert(results.size() > 0);
+  testAssert(maxBatchSize > 0);
+  int bestIdx = 0;
+  for(int i = 1; i<results.size(); i++) {
+    if(BenchmarkResults::isBetterNNEvalsPerSecond(results[i],maxBatchSize,results[bestIdx],maxBatchSize))
+      bestIdx = i;
+  }
+  return clampAutoBatchValue((int)round(results[bestIdx].avgBatchSize),1,maxBatchSize);
+}
+
+vector<int> PlayUtils::getAutoBatchProfileCandidates(
+  int maxBatchSize,
+  int centerBatchSize,
+  int profileBudget
+) {
+  testAssert(maxBatchSize > 0);
+  testAssert(profileBudget > 0);
+  centerBatchSize = clampAutoBatchValue(centerBatchSize,1,maxBatchSize);
+  const int actualBudget = std::min(profileBudget,maxBatchSize);
+  vector<int> batches;
+  auto add = [&](int value) {
+    value = clampAutoBatchValue(value,1,maxBatchSize);
+    if(std::find(batches.begin(),batches.end(),value) == batches.end() && batches.size() < actualBudget)
+      batches.push_back(value);
+  };
+
+  // The MAX-profile wide scout consumes one unique profile from the hard budget.
+  add(maxBatchSize);
+  add(centerBatchSize);
+  add(centerBatchSize-1);
+  add(centerBatchSize+1);
+  add(centerBatchSize-2);
+  add(centerBatchSize+2);
+
+  // Larger budgets buy a few global checks before filling the largest untested gaps.
+  add((centerBatchSize+1)/2);
+  add(2*centerBatchSize);
+  while(batches.size() < actualBudget) {
+    vector<int> sortedBatches = batches;
+    sort(sortedBatches.begin(),sortedBatches.end());
+    int bestGap = -1;
+    int bestValue = -1;
+    int previous = 0;
+    for(int value: sortedBatches) {
+      const int gap = value - previous - 1;
+      if(gap > bestGap) {
+        bestGap = gap;
+        bestValue = previous + (gap+1)/2;
+      }
+      previous = value;
+    }
+    const int finalGap = maxBatchSize - previous;
+    if(finalGap > bestGap) {
+      bestGap = finalGap;
+      bestValue = previous + (finalGap+1)/2;
+    }
+    if(bestGap <= 0)
+      break;
+    add(bestValue);
+  }
+  return batches;
+}
+
+vector<int> PlayUtils::getAutoBatchThreadStencil(int maxBatchSize, int numServerThreads) {
+  testAssert(maxBatchSize > 0);
+  testAssert(numServerThreads > 0);
+  const int maxThreads = 4096;
+  const int delta = std::min(2047,std::max(2,(int)round(maxBatchSize/5.0)));
+  const int center = clampAutoBatchValue(
+    (int)std::min<int64_t>((int64_t)(numServerThreads+1) * maxBatchSize,maxThreads),
+    1,
+    maxThreads
+  );
+  vector<int> threads;
+  auto add = [&](int value) {
+    value = clampAutoBatchValue(value,1,maxThreads);
+    if(std::find(threads.begin(),threads.end(),value) == threads.end())
+      threads.push_back(value);
+  };
+  add(center-delta);
+  add(center);
+  add(center+delta);
+  for(int offset = 1; threads.size() < 3 && offset < maxThreads; offset++) {
+    add(center-offset);
+    add(center+offset);
+  }
+  sort(threads.begin(),threads.end());
+  return threads;
+}
+
+PlayUtils::AutoBatchProfileResult PlayUtils::summarizeAutoBatchProfile(
+  int maxBatchSize,
+  const vector<BenchmarkResults>& results
+) {
+  testAssert(maxBatchSize > 0);
+  testAssert(results.size() > 0);
+  vector<double> rates;
+  rates.reserve(results.size());
+  int bestIdx = 0;
+  for(int i = 0; i<results.size(); i++) {
+    rates.push_back(results[i].getNNEvalsPerSecond());
+    if(i > 0 && BenchmarkResults::isBetterNNEvalsPerSecond(results[i],maxBatchSize,results[bestIdx],maxBatchSize))
+      bestIdx = i;
+  }
+  sort(rates.begin(),rates.end());
+  const int mid = (int)rates.size()/2;
+  const double median = rates.size() % 2 == 1 ? rates[mid] : 0.5*(rates[mid-1]+rates[mid]);
+  return {maxBatchSize,median,results[bestIdx],results};
+}
+
+bool PlayUtils::isBetterAutoBatchProfile(
+  const AutoBatchProfileResult& candidate,
+  const AutoBatchProfileResult& incumbent
+) {
+  if(candidate.medianNNEvalsPerSecond != incumbent.medianNNEvalsPerSecond)
+    return candidate.medianNNEvalsPerSecond > incumbent.medianNNEvalsPerSecond;
+  if(candidate.maxBatchSize != incumbent.maxBatchSize)
+    return candidate.maxBatchSize < incumbent.maxBatchSize;
+  return candidate.finalist.numThreads < incumbent.finalist.numThreads;
+}
+
+double PlayUtils::getPooledNNEvalsPerSecond(const vector<BenchmarkResults>& results) {
+  int64_t totalNNEvals = 0;
+  double totalSeconds = 0.0;
+  for(const BenchmarkResults& result: results) {
+    totalNNEvals += result.numNNEvals;
+    totalSeconds += result.totalSeconds;
+  }
+  return totalSeconds > 0.0 ? totalNNEvals / totalSeconds : 0.0;
+}
+
+bool PlayUtils::isBetterAutoBatchConfirmation(
+  int candidateMaxBatchSize,
+  int candidateNumThreads,
+  const vector<BenchmarkResults>& candidateResults,
+  int incumbentMaxBatchSize,
+  int incumbentNumThreads,
+  const vector<BenchmarkResults>& incumbentResults
+) {
+  const double candidateRate = getPooledNNEvalsPerSecond(candidateResults);
+  const double incumbentRate = getPooledNNEvalsPerSecond(incumbentResults);
+  if(candidateRate != incumbentRate)
+    return candidateRate > incumbentRate;
+  if(candidateMaxBatchSize != incumbentMaxBatchSize)
+    return candidateMaxBatchSize < incumbentMaxBatchSize;
+  return candidateNumThreads < incumbentNumThreads;
+}
+
+int PlayUtils::getMaxUntestedBatchSizeGap(
+  const vector<int>& testedBatchSizes,
+  int maxBatchSize
+) {
+  testAssert(maxBatchSize > 0);
+  vector<int> sortedBatches;
+  for(int value: testedBatchSizes) {
+    if(value >= 1 && value <= maxBatchSize && std::find(sortedBatches.begin(),sortedBatches.end(),value) == sortedBatches.end())
+      sortedBatches.push_back(value);
+  }
+  sort(sortedBatches.begin(),sortedBatches.end());
+  int maxGap = 0;
+  int previous = 0;
+  for(int value: sortedBatches) {
+    maxGap = std::max(maxGap,value-previous-1);
+    previous = value;
+  }
+  maxGap = std::max(maxGap,maxBatchSize-previous);
+  return maxGap;
+}
+
 //From some test matches by lightvector using g170
 static constexpr double eloGainPerDoubling = 250;
 

--- a/cpp/program/playutils.h
+++ b/cpp/program/playutils.h
@@ -142,8 +142,16 @@ namespace PlayUtils {
     std::string toString() const;
     std::string toStringWithElo(const BenchmarkResults* baseline, double secondsPerGameMove) const;
 
+    double getNNEvalsPerSecond() const;
     double computeEloEffect(double secondsPerGameMove) const;
 
+    //Break equal-throughput ties by smaller max batch size, then fewer search threads.
+    static bool isBetterNNEvalsPerSecond(
+      const BenchmarkResults& candidate,
+      int candidateMaxBatchSize,
+      const BenchmarkResults& incumbent,
+      int incumbentMaxBatchSize
+    );
     static void printEloComparison(const std::vector<BenchmarkResults>& results, double secondsPerGameMove);
   };
 

--- a/cpp/program/playutils.h
+++ b/cpp/program/playutils.h
@@ -155,6 +155,63 @@ namespace PlayUtils {
     static void printEloComparison(const std::vector<BenchmarkResults>& results, double secondsPerGameMove);
   };
 
+  enum BenchmarkTuneMode {
+    BENCHMARK_TUNE_AUTO_THREADS,
+    BENCHMARK_TUNE_FIXED_THREADS,
+    BENCHMARK_TUNE_EXPLICIT_BATCH_GRID,
+    BENCHMARK_TUNE_AUTO_BATCH,
+  };
+
+  struct AutoBatchProfileResult {
+    int maxBatchSize;
+    double medianNNEvalsPerSecond;
+    BenchmarkResults finalist;
+    std::vector<BenchmarkResults> trials;
+  };
+
+  // Pure helpers for the raw-throughput max-batch tuner.
+  BenchmarkTuneMode getBenchmarkTuneMode(
+    bool autoTuneThreadsExplicitly,
+    bool threadsSpecified,
+    bool explicitBatchGridSpecified,
+    bool autoBatchSpecified,
+    bool fixedBatchSpecified,
+    bool halfBatchSpecified,
+    bool profileBudgetSpecified
+  );
+  std::vector<int> getAutoBatchScoutThreads(int numServerThreads, int maxBatchSize);
+  int getAutoBatchScoutBatchSize(
+    const std::vector<BenchmarkResults>& results,
+    int maxBatchSize
+  );
+  std::vector<int> getAutoBatchProfileCandidates(
+    int maxBatchSize,
+    int centerBatchSize,
+    int profileBudget
+  );
+  std::vector<int> getAutoBatchThreadStencil(int maxBatchSize, int numServerThreads);
+  AutoBatchProfileResult summarizeAutoBatchProfile(
+    int maxBatchSize,
+    const std::vector<BenchmarkResults>& results
+  );
+  bool isBetterAutoBatchProfile(
+    const AutoBatchProfileResult& candidate,
+    const AutoBatchProfileResult& incumbent
+  );
+  double getPooledNNEvalsPerSecond(const std::vector<BenchmarkResults>& results);
+  bool isBetterAutoBatchConfirmation(
+    int candidateMaxBatchSize,
+    int candidateNumThreads,
+    const std::vector<BenchmarkResults>& candidateResults,
+    int incumbentMaxBatchSize,
+    int incumbentNumThreads,
+    const std::vector<BenchmarkResults>& incumbentResults
+  );
+  int getMaxUntestedBatchSizeGap(
+    const std::vector<int>& testedBatchSizes,
+    int maxBatchSize
+  );
+
   //Run benchmark on sgf positions. ALSO prints to stdout the ongoing result as it benchmarks.
   BenchmarkResults benchmarkSearchOnPositionsAndPrint(
     const SearchParams& params,

--- a/cpp/tests/results/cmd/benchmark_help.stdout
+++ b/cpp/tests/results/cmd/benchmark_help.stdout
@@ -47,6 +47,10 @@ Where:
    -fixed-batch-size <NUM>
      Set max batch size to this fixed value
 
+   -max-batch-sizes <BATCHES>
+     Test the Cartesian product of these exact max batch sizes and
+     explicitly specified -threads, comma-separated (cannot use -tune)
+
    -half-batch-size
      Set max batch size to half of the number of threads
 

--- a/cpp/tests/results/cmd/benchmark_help.stdout
+++ b/cpp/tests/results/cmd/benchmark_help.stdout
@@ -51,6 +51,14 @@ Where:
      Test the Cartesian product of these exact max batch sizes and
      explicitly specified -threads, comma-separated (cannot use -tune)
 
+   -tune-max-batch-size <MAX>
+     Efficiently tune raw NN throughput over exact max batch sizes and
+     thread counts, up to this memory-safe max batch size
+
+   -tune-max-batch-profile-budget <N>
+     Maximum number of unique exact max batch profiles to build during
+     -tune-max-batch-size (default 6)
+
    -half-batch-size
      Set max batch size to half of the number of threads
 

--- a/cpp/tests/testmisc.cpp
+++ b/cpp/tests/testmisc.cpp
@@ -82,10 +82,17 @@ void Tests::runBenchmarkResultsTests() {
     false,false,false,true,false,false,true
   ) == PlayUtils::BENCHMARK_TUNE_AUTO_BATCH);
   const vector<vector<bool>> invalidModes = {
+    {false,false,false,false,true,true,false},
+    {true,true,false,false,false,false,false},
     {true,false,false,true,false,false,false},
     {false,true,false,true,false,false,false},
     {false,false,true,true,false,false,false},
     {false,false,false,true,true,false,false},
+    {false,false,false,true,false,true,false},
+    {true,false,true,false,false,false,false},
+    {false,true,true,false,true,false,false},
+    {false,true,true,false,false,true,false},
+    {false,false,true,false,false,false,false},
     {false,false,false,false,false,false,true},
   };
   for(const vector<bool>& mode: invalidModes) {

--- a/cpp/tests/testmisc.cpp
+++ b/cpp/tests/testmisc.cpp
@@ -1,8 +1,10 @@
 #include "../tests/tests.h"
 
 #include "../core/fileutils.h"
+#include "../command/commandline.h"
 #include "../dataio/files.h"
 #include "../dataio/loadmodel.h"
+#include "../program/playutils.h"
 
 #include <chrono>
 #include <thread>
@@ -11,6 +13,64 @@
 #include "../core/using.h"
 //------------------------
 using namespace TestCommon;
+
+void Tests::runBenchmarkResultsTests() {
+  PlayUtils::BenchmarkResults result;
+  testAssert(result.getNNEvalsPerSecond() == 0.0);
+
+  result.numNNEvals = 4321;
+  result.totalSeconds = 2.0;
+  testAssert(result.getNNEvalsPerSecond() == 2160.5);
+
+  PlayUtils::BenchmarkResults moreEvalsButSlower;
+  moreEvalsButSlower.numNNEvals = 5000;
+  moreEvalsButSlower.totalSeconds = 4.0;
+  PlayUtils::BenchmarkResults fewerEvalsButFaster;
+  fewerEvalsButFaster.numNNEvals = 3000;
+  fewerEvalsButFaster.totalSeconds = 2.0;
+  testAssert(PlayUtils::BenchmarkResults::isBetterNNEvalsPerSecond(
+    fewerEvalsButFaster,20,moreEvalsButSlower,18
+  ));
+  testAssert(!PlayUtils::BenchmarkResults::isBetterNNEvalsPerSecond(
+    moreEvalsButSlower,18,fewerEvalsButFaster,20
+  ));
+
+  PlayUtils::BenchmarkResults equalRateMoreThreads;
+  equalRateMoreThreads.numNNEvals = 3000;
+  equalRateMoreThreads.totalSeconds = 2.0;
+  equalRateMoreThreads.numThreads = 64;
+  PlayUtils::BenchmarkResults equalRateFewerThreads = equalRateMoreThreads;
+  equalRateFewerThreads.numThreads = 60;
+  testAssert(PlayUtils::BenchmarkResults::isBetterNNEvalsPerSecond(
+    equalRateMoreThreads,18,equalRateFewerThreads,20
+  ));
+  testAssert(PlayUtils::BenchmarkResults::isBetterNNEvalsPerSecond(
+    equalRateFewerThreads,18,equalRateMoreThreads,18
+  ));
+  testAssert(!PlayUtils::BenchmarkResults::isBetterNNEvalsPerSecond(
+    equalRateMoreThreads,18,equalRateFewerThreads,18
+  ));
+
+  const vector<int> parsed = KataGoCommandLine::parseCommaSeparatedUniqueInts(
+    "18, 20,22",1,65536,"Test value"
+  );
+  testAssert(parsed == vector<int>({18,20,22}));
+  const vector<string> invalidLists = {"", "18,,20", "0", "65537", "abc", "18,18"};
+  for(const string& invalidList: invalidLists) {
+    bool threw = false;
+    try {
+      (void)KataGoCommandLine::parseCommaSeparatedUniqueInts(
+        invalidList,1,65536,"Test value"
+      );
+    }
+    catch(const StringError&) {
+      threw = true;
+    }
+    testAssert(threw);
+  }
+
+  cout << "testbenchmarkresults okay" << endl;
+}
 
 void Tests::runCollectFilesTests() {
   {

--- a/cpp/tests/testmisc.cpp
+++ b/cpp/tests/testmisc.cpp
@@ -69,6 +69,118 @@ void Tests::runBenchmarkResultsTests() {
     testAssert(threw);
   }
 
+  testAssert(PlayUtils::getBenchmarkTuneMode(
+    false,false,false,false,false,false,false
+  ) == PlayUtils::BENCHMARK_TUNE_AUTO_THREADS);
+  testAssert(PlayUtils::getBenchmarkTuneMode(
+    false,true,false,false,false,false,false
+  ) == PlayUtils::BENCHMARK_TUNE_FIXED_THREADS);
+  testAssert(PlayUtils::getBenchmarkTuneMode(
+    false,true,true,false,false,false,false
+  ) == PlayUtils::BENCHMARK_TUNE_EXPLICIT_BATCH_GRID);
+  testAssert(PlayUtils::getBenchmarkTuneMode(
+    false,false,false,true,false,false,true
+  ) == PlayUtils::BENCHMARK_TUNE_AUTO_BATCH);
+  const vector<vector<bool>> invalidModes = {
+    {true,false,false,true,false,false,false},
+    {false,true,false,true,false,false,false},
+    {false,false,true,true,false,false,false},
+    {false,false,false,true,true,false,false},
+    {false,false,false,false,false,false,true},
+  };
+  for(const vector<bool>& mode: invalidModes) {
+    bool threw = false;
+    try {
+      (void)PlayUtils::getBenchmarkTuneMode(
+        mode[0],mode[1],mode[2],mode[3],mode[4],mode[5],mode[6]
+      );
+    }
+    catch(const StringError&) {
+      threw = true;
+    }
+    testAssert(threw);
+  }
+
+  const vector<int> scoutThreads = PlayUtils::getAutoBatchScoutThreads(2,128);
+  testAssert(scoutThreads.size() == 5);
+  testAssert(std::find(scoutThreads.begin(),scoutThreads.end(),32) != scoutThreads.end());
+  testAssert(std::find(scoutThreads.begin(),scoutThreads.end(),64) != scoutThreads.end());
+  testAssert(std::find(scoutThreads.begin(),scoutThreads.end(),128) != scoutThreads.end());
+
+  vector<PlayUtils::BenchmarkResults> nonMonotonicScout(4);
+  for(int i = 0; i<nonMonotonicScout.size(); i++) {
+    nonMonotonicScout[i].numThreads = 16 << i;
+    nonMonotonicScout[i].numNNEvals = 100 + 10*i;
+    nonMonotonicScout[i].totalSeconds = 1.0;
+    nonMonotonicScout[i].avgBatchSize = 8+i;
+  }
+  nonMonotonicScout[1].numNNEvals = 300;
+  nonMonotonicScout[1].avgBatchSize = 20.2;
+  nonMonotonicScout[2].numNNEvals = 150;
+  nonMonotonicScout[3].numNNEvals = 250;
+  testAssert(PlayUtils::getAutoBatchScoutBatchSize(nonMonotonicScout,128) == 20);
+
+  const vector<int> profileCandidates = PlayUtils::getAutoBatchProfileCandidates(128,20,6);
+  testAssert(profileCandidates == vector<int>({128,20,19,21,18,22}));
+  const vector<int> boundaryCandidates = PlayUtils::getAutoBatchProfileCandidates(3,1,10);
+  testAssert(boundaryCandidates.size() == 3);
+  testAssert(boundaryCandidates[0] == 3);
+  testAssert(std::set<int>(boundaryCandidates.begin(),boundaryCandidates.end()).size() == boundaryCandidates.size());
+
+  const vector<int> batch20Stencil = PlayUtils::getAutoBatchThreadStencil(20,2);
+  testAssert(batch20Stencil == vector<int>({56,60,64}));
+
+  vector<PlayUtils::BenchmarkResults> spikyProfile(3);
+  spikyProfile[0].numThreads = 56;
+  spikyProfile[0].numNNEvals = 100;
+  spikyProfile[0].totalSeconds = 1.0;
+  spikyProfile[1].numThreads = 60;
+  spikyProfile[1].numNNEvals = 500;
+  spikyProfile[1].totalSeconds = 1.0;
+  spikyProfile[2].numThreads = 64;
+  spikyProfile[2].numNNEvals = 110;
+  spikyProfile[2].totalSeconds = 1.0;
+  const PlayUtils::AutoBatchProfileResult spikySummary =
+    PlayUtils::summarizeAutoBatchProfile(20,spikyProfile);
+  testAssert(spikySummary.medianNNEvalsPerSecond == 110.0);
+  testAssert(spikySummary.finalist.numThreads == 60);
+
+  vector<PlayUtils::BenchmarkResults> confirmationA(2);
+  confirmationA[0].numNNEvals = 100;
+  confirmationA[0].totalSeconds = 1.0;
+  confirmationA[1].numNNEvals = 100;
+  confirmationA[1].totalSeconds = 9.0;
+  vector<PlayUtils::BenchmarkResults> confirmationB(2);
+  confirmationB[0].numNNEvals = 30;
+  confirmationB[0].totalSeconds = 1.0;
+  confirmationB[1].numNNEvals = 30;
+  confirmationB[1].totalSeconds = 1.0;
+  testAssert(
+    0.5 * (confirmationA[0].getNNEvalsPerSecond() + confirmationA[1].getNNEvalsPerSecond()) >
+    0.5 * (confirmationB[0].getNNEvalsPerSecond() + confirmationB[1].getNNEvalsPerSecond())
+  );
+  testAssert(PlayUtils::getPooledNNEvalsPerSecond(confirmationA) == 20.0);
+  testAssert(PlayUtils::getPooledNNEvalsPerSecond(confirmationB) == 30.0);
+  testAssert(PlayUtils::isBetterAutoBatchConfirmation(
+    21,63,confirmationB,20,60,confirmationA
+  ));
+  testAssert(PlayUtils::isBetterAutoBatchConfirmation(
+    19,64,confirmationB,20,60,confirmationB
+  ));
+  testAssert(PlayUtils::isBetterAutoBatchConfirmation(
+    20,60,confirmationB,20,64,confirmationB
+  ));
+
+  PlayUtils::AutoBatchProfileResult equalMedianLargerBatch = spikySummary;
+  equalMedianLargerBatch.maxBatchSize = 21;
+  PlayUtils::AutoBatchProfileResult equalMedianSmallerBatch = spikySummary;
+  equalMedianSmallerBatch.maxBatchSize = 20;
+  testAssert(PlayUtils::isBetterAutoBatchProfile(
+    equalMedianSmallerBatch,equalMedianLargerBatch
+  ));
+
+  testAssert(PlayUtils::getMaxUntestedBatchSizeGap(vector<int>({18,19,20,21,22,128}),128) == 105);
+
   cout << "testbenchmarkresults okay" << endl;
 }
 

--- a/cpp/tests/tests.h
+++ b/cpp/tests/tests.h
@@ -108,6 +108,7 @@ namespace Tests {
   //testmisc.cpp
   void runCollectFilesTests();
   void runLoadModelTests();
+  void runBenchmarkResultsTests();
 
   //testbook.cpp
   void runBookTests();


### PR DESCRIPTION
﻿## Summary

This started as a TensorRT CUDA Graph fix and now also includes an opt-in, bounded benchmark tuner for `nnMaxBatchSize`.

- Add opt-in `trtUseCudaGraph`, with prewarmed graphs up to `trtCudaGraphMaxBatchSize` (default 16); larger batches still use `enqueueV3`.
- Use pinned host staging and keep all H2D/D2H copies on the NN server stream, with one final sync for the five outputs.
- On TensorRT 10+, share one immutable deserialized engine between same-model handles on the same GPU. Contexts, activation memory, buffers, streams, and Graph caches remain private.
- Add an exact benchmark grid: `-max-batch-sizes <BATCHES> -threads <THREADS>`.
- Add bounded automatic tuning: `-tune-max-batch-size <MAX>` and optional `-tune-max-batch-profile-budget <N>` (default 6).

The new benchmark modes are opt-in. Existing benchmark behavior and inference arithmetic are unchanged.

## TensorRT benchmark

RTX PRO 6000 Blackwell, CUDA 13.0, TensorRT 10.16.1, NHWC FP16, `b11c768h12nbt3tflrs-fson-silu`, official `benchmark -v 1600 -n 20 -t 16,32,64,128`, fixed seed/symmetry, Graph cap 16. Cells are `nnEvals/s / avgBatch`; 2NN Graph is the mean of two runs.

| Threads | 1NN off | 1NN Graph | 2NN off | 2NN Graph |
|---:|---:|---:|---:|---:|
| 16 | 1628 / 7.93 | 1859 / 7.92 | 1133 / 5.24 | 2273 / 5.06 |
| 32 | 2466 / 15.95 | 2562 / 15.84 | 2255 / 10.36 | 2951 / 9.43 |
| 64 | 2974 / 31.73 | 2976 / 31.98 | 3179 / 19.92 | 3286 / 19.73 |
| 128 | 2992 / 63.80 | 2954 / 64.06 | 3074 / 40.51 | 3125 / 40.41 |

The previous 2NN+Graph path had a repeatable feedback collapse at t32/t64/t128: 1341/2139/2539 evals/s with avgBatch 4.94/10.06/20.16. The new path reaches 2951/3286/3125 with avgBatch 9.43/19.73/40.41.

Same-condition CUDA reference:

| Threads | CUDA | TRT 1NN Graph | TRT 2NN Graph |
|---:|---:|---:|---:|
| 16 | 1835 | 1859 (+1.3%) | 2273 (+23.9%) |
| 32 | 2269 | 2562 (+12.9%) | 2951 (+30.1%) |
| 64 | 2674 | 2976 (+11.3%) | 3286 (+22.9%) |
| 128 | 2726 | 2954 (+8.4%) | 3125 (+14.6%) |

This remains hardware-dependent; I would keep one server per GPU as the conservative default and let benchmark data decide where two consumers help.

## Automatic max-batch tuning

A full forward+reverse calibration used exact B18-B22 and threads 48-72: 70 measured cells. Its paired best was B20/64 at 3389.81 nnEvals/s; B20 was effectively flat from 60-72, while B22 hit a clear tactic/profile cliff.

The automatic run was:

```text
benchmark -v 1600 -n 20 \
  -tune-max-batch-size 128 \
  -tune-max-batch-profile-budget 6
```

It performs a five-point global thread scout at the user-provided memory-safe MAX, tests nearby exact profiles with a three-thread stencil, ranks profiles by their three-point median, then confirms the top two as A-B-B-A using pooled `sum(nnEvals) / sum(seconds)`.

It tested exact profiles `128,19,18,20,17,21` and used 24 measured cases, 65.7% fewer than the paired grid:

| Finalist | Pooled nnEvals/s | Two-run jitter |
|---|---:|---:|
| B19, 57 threads | 3422.26 | 0.24% |
| B20, 60 threads | **3462.86** | 0.30% |

So it recovered the same B20 optimum in 299.7 seconds, including cached plan loads and one previously uncached exact profile. It prints the tested profiles, largest untested gap, boundary warnings, and a small explicit follow-up suggestion when adjacent threads are within 0.5%. The MAX is always explicit so the tuner cannot silently exceed the user's memory limit.

## Memory and startup

Cached plan, 10 Hz sampling:

| Configuration | Startup | Peak GPU | Peak RSS |
|---|---:|---:|---:|
| 1NN off | 4.150 s | 1242 MiB | 1689.7 MiB |
| 1NN Graph | 5.666 s | 1290 MiB | 1680.3 MiB |
| 2NN off | 4.148 s | 1758 MiB | 1689.9 MiB |
| 2NN Graph | 7.142 s | 1864 MiB | 1793.6 MiB |

Compared with the old 2NN path, engine reuse saved 160 MiB GPU and 771 MiB peak RSS without Graphs; the 2NN Graph run saved 160 MiB GPU and about 1.45 GiB peak RSS.

## Validation

- TensorRT 10.16.1 / CUDA 13 Release build and `runtests` pass; dummy Release build, help snapshot, CLI conflict tests, and `git diff --check` also pass.
- Full 19x19 `testgpuerror` passed with two same-GPU NN servers, NHWC FP16, and Graphs. Closest FP16 margins were 0.297x / 0.222x of the limits. A rectangular quick run passed at 0.199x / 0.0963x.
- Batched/unbatched statistics matched. The tuner only chooses benchmark parameters; it does not relax precision or change the numerical path.
- Both handles log one plan load plus one shared-engine reuse and private Graph prewarm; no fallback or CUDA/TRT error.
- TRT 8.6/9 headers and guards were audited, but runtime testing on those versions is still wanted, so this remains a draft.


## Windows / TensorRT 10.16 validation

A native Windows build with TensorRT 10.16.1.11, CUDA 12.8, and MSVC 2022 passed `runtests` and generated/reused a real b11 B8 FP16 plan with two same-GPU NN servers and Graphs 1-8. Modern Protobuf config packages are linked through protobuf::libprotobuf so MSVC uses the import library and transitive dependencies correctly.
## TensorRT 10.16 shared-engine initialization stability

On a Windows RTX 3080 Laptop / TensorRT 10.16.1.11 system, two graph-enabled handles could intermittently fail during concurrent context creation and Graph prewarm with Myelin `exec_with_offset` followed by `syncStreams`. The failure occurred before inference and reproduced with cached B8/B30/B32 plans.

Context initialization and Graph prewarm are now serialized per shared engine when CUDA Graphs are enabled. Graph-free initialization and all inference remain concurrent; contexts, activation memory, buffers, streams, and Graph caches are still private. Rapid-restart coverage passed 12/12 graph-enabled initializations across B8, B30, and B32 after the change.

The local b11 tuner selected B8 / 22 search threads / two NN servers / Graph cap 8. Official quick `testgpuerror` passed; the closest FP16 margins were 0.444x and 0.482x of the allowed limits, and batched/unbatched statistics were identical. No precision setting or tolerance was changed.