### PR TITLE
Serialize TensorRT engine builds across GPUs

### DIFF
--- a/cpp/neuralnet/trtbackend.cpp
+++ b/cpp/neuralnet/trtbackend.cpp
@@ -1362,7 +1362,10 @@ struct ComputeHandle {
     string plan;
     {
       static mutex tuneMutex;
-      tuneMutex.lock();
+      // TensorRT 10.16 has been observed to segfault when builders on different devices call
+      // buildSerializedNetwork concurrently, particularly with timing-cache hits. Keep both cache
+      // access and engine building serialized, and use RAII so exceptions cannot leave the mutex held.
+      lock_guard<mutex> tuneLock(tuneMutex);
 
       auto cacheDir = HomeData::getHomeDataDir(true, ctx->homeDataDirOverride);
       cacheDir += "/trtcache";
@@ -1456,9 +1459,7 @@ struct ComputeHandle {
         writeFileAtomically(planCacheFile, plan.data(), plan.size());
         logger->write("Saved new plan cache to " + planCacheFile);
         plan.erase(plan.size() - 64 - paramStr.size());
-        tuneMutex.unlock();
       } else {
-        tuneMutex.unlock();
         logger->write("Using existing plan cache at " + planCacheFile);
       }
 #else
@@ -1511,9 +1512,7 @@ struct ComputeHandle {
         writeFileAtomically(
           timingCacheFile, static_cast<char*>(serializedTimingCache->data()), serializedTimingCache->size());
         logger->write("Saved new timing cache to " + timingCacheFile);
-        tuneMutex.unlock();
       } else {
-        tuneMutex.unlock();
         planBuffer.reset(builder->buildSerializedNetwork(*model->network, *config));
         if(!planBuffer) {
           throw StringError("TensorRT backend: failed to create plan");


### PR DESCRIPTION
## Summary

- Keep `buildSerializedNetwork()` under the existing process-wide TensorRT tuning mutex, including timing-cache hits.
- Use RAII for the mutex so a build/cache exception cannot leave later NN server threads deadlocked.

## Why

With TensorRT 10.16.1, concurrent warm-cache engine builds on different GPUs can fail nondeterministically. The existing cache-hit path released `tuneMutex` immediately before `buildSerializedNetwork()`, allowing all GPU threads to enter TensorRT's builder at once. On an 8x RTX 5060 Ti machine this reproduced as two SIGSEGVs and one hang, always after both threads loaded the timing cache and before either engine finished initialization.

This only serializes engine construction during startup. Engine deserialization, execution contexts, and inference remain per-GPU and concurrent. It does not change the graph, precision, or inference hot path.

## Validation

Tested with KataGo v1.17.1, TensorRT 10.16.1, CUDA 13.2, and `b11c768h12nbt3tflrs-fson-silu`:

- dual-GPU warm-cache stress: 12/12 passes after the fix
- 8-GPU cold- and warm-cache benchmark: both pass, with every GPU processing rows
- `USE_CACHE_TENSORRT_PLAN=1`: builds and passes dual-GPU cold/warm smoke tests
- `katago runtests`: all tests pass
