### PR TITLE
Fix OpenCL backend NCHW WMMA layout identifier typo

### DIFF
--- a/cpp/neuralnet/openclbackend.cpp
+++ b/cpp/neuralnet/openclbackend.cpp
@@ -1088,7 +1088,7 @@ struct ConvLayer {
   const int nnYLen;
   const int paddedNNXYLen;
 
-  bool usingHGemmWmmaNHCW; // For 1x1 convs
+  bool usingHGemmWmmaNCHW; // For 1x1 convs
 
   int numTilesX;
   int numTilesY;
@@ -1125,7 +1125,7 @@ struct ConvLayer {
       throw StringError("OpenCL backend: Encountered convolution dilation factors other than 1, not supported");
 
     //Initial values unless overrided below
-    usingHGemmWmmaNHCW = false;
+    usingHGemmWmmaNCHW = false;
     numTilesX = 0;
     numTilesY = 0;
     inTileXYSize = 0;
@@ -1142,7 +1142,7 @@ struct ConvLayer {
       filter = createReadOnlyBuffer(handle,transWeights,useFP16);
       if(handle->usingFP16TensorCoresFor1x1) {
         if(inChannels % handle->getHGemmWmmaNCHWRequiredCDivisor() == 0 && outChannels % handle->getHGemmWmmaNCHWRequiredCDivisor() == 0) {
-          usingHGemmWmmaNHCW = true;
+          usingHGemmWmmaNCHW = true;
         }
       }
     }
@@ -1276,7 +1276,7 @@ struct ConvLayer {
 
   void apply(ComputeHandleInternal* handle, int batchSize, cl_mem input, cl_mem output, cl_mem convWorkspace, cl_mem convWorkspace2) const {
     if(convXSize == 1 && convYSize == 1) {
-      if(!usingHGemmWmmaNHCW) {
+      if(!usingHGemmWmmaNCHW) {
         int filterStride = 0; //Reuse same filter for all matrices in batch
         int inputStride = paddedNNXYLen * inChannels;
         int outputStride = paddedNNXYLen * outChannels;
@@ -2269,7 +2269,7 @@ struct TransformerMatMulLayer {
   const int inChannels;
   const int outChannels;
   const int paddedNNXYLen;
-  bool usingHGemmWmmaNHCW;
+  bool usingHGemmWmmaNCHW;
 
   cl_mem filter;
 
@@ -2281,7 +2281,7 @@ struct TransformerMatMulLayer {
     inChannels(desc->inChannels),
     outChannels(desc->outChannels),
     paddedNNXYLen(handle->paddedNNXYLen),
-    usingHGemmWmmaNHCW(false)
+    usingHGemmWmmaNCHW(false)
   {
     testAssert(desc->weights.size() == (size_t)(inChannels * outChannels));
     // MatMulLayerDesc weights are (inC, outC): weights[ic * outC + oc]
@@ -2292,7 +2292,7 @@ struct TransformerMatMulLayer {
 
     if(handle->usingFP16TensorCoresFor1x1) {
       if(inChannels % handle->getHGemmWmmaNCHWRequiredCDivisor() == 0 && outChannels % handle->getHGemmWmmaNCHWRequiredCDivisor() == 0) {
-        usingHGemmWmmaNHCW = true;
+        usingHGemmWmmaNCHW = true;
       }
     }
   }
@@ -2305,7 +2305,7 @@ struct TransformerMatMulLayer {
   // This is identical to a 1x1 convolution: output[n,oc,xy] = sum_ic input[n,ic,xy] * weight[ic,oc]
   void apply(ComputeHandleInternal* handle, int batchSize, cl_mem input, cl_mem output, cl_mem mask, cl_mem convWorkspace) const {
     (void)mask;
-    if(!usingHGemmWmmaNHCW) {
+    if(!usingHGemmWmmaNCHW) {
       (void)convWorkspace;
       int filterStride = 0; // Reuse same filter for all batch elements
       int inputStride = paddedNNXYLen * inChannels;


### PR DESCRIPTION
# Summary
Errata fix on OpenCL Backend
This change corrects a typographical error in the OpenCL WMMA path flags name 

**usingHGemmWmmaNHCW** is renamed to **usingHGemmWmmaNCHW**

The implementation already uses NCHW layout, so this is a only naming-only correction and doesn't change any logics.
