### PR TITLE
Fix PosWriter off-by-one so each output file holds at most maxPosesPerOutFile positions

### DIFF
--- a/cpp/dataio/poswriter.cpp
+++ b/cpp/dataio/poswriter.cpp
@@ -53,7 +53,7 @@ static void writeLoop(
     if(!suc)
       break;
 
-    if(out == NULL || numWrittenThisFile > maxPosesPerOutFile) {
+    if(out == NULL || numWrittenThisFile >= maxPosesPerOutFile) {
       if(out != NULL) {
         out->close();
         delete out;


### PR DESCRIPTION
## Summary
Fixes an off-by-one error. For example, previously, a file configured with `maxPosesPerOutFile = 100000` could contain 100,001 positions. By changing `>` to `>=`, this ensures a new file is opened once the configured limit is reached

## Testing
Tested locally with a limit of 1 and 3 records:
- Before: one file contained 2 records, another file contained 1 record
- After: each file contained 1 record

---

First PR! Wanted to keep it small. Came across the repo recently, and became interested because of things like its distributed self-play approach, recent switch to transformers, and sharing of model internals studies https://github.com/lightvector/katagostudies