### PR TITLE
Fix contribute watchOngoingGameInFile for non-ASCII paths on Windows

### DIFF
--- a/cpp/command/contribute.cpp
+++ b/cpp/command/contribute.cpp
@@ -22,6 +22,15 @@
 #include "../command/commandline.h"
 #include "../main.h"
 
+#if __MINGW32__
+// `std::wstring_convert` needs explicit including in case of MINGW
+#include <locale>
+#endif
+
+#ifdef OS_IS_WINDOWS
+#include <codecvt>
+#endif
+
 #ifndef BUILD_DISTRIBUTED
 
 int MainCmds::contribute(const std::vector<std::string>& args) {
@@ -802,10 +811,17 @@ int MainCmds::contribute(const vector<string>& args) {
     std::unique_ptr<std::ostream> outputEachMove = nullptr;
     std::function<void()> flushOutputEachMove = nullptr;
     if(gameLoopThreadIdx == 0 && watchOngoingGameInFile) {
-      // TODO someday - doesn't handle non-ascii paths.
 #ifdef OS_IS_WINDOWS
+      std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+      std::wstring watchOngoingGameInFileWideName;
+      try {
+        watchOngoingGameInFileWideName = converter.from_bytes(watchOngoingGameInFileName);
+      }
+      catch(const std::range_error&) {
+        throw StringError("watchOngoingGameFileName is not valid UTF-8: " + watchOngoingGameInFileName);
+      }
       FILE* file = NULL;
-      fopen_s(&file, watchOngoingGameInFileName.c_str(), "a");
+      file = _wfopen(watchOngoingGameInFileWideName.c_str(), L"a");
       if(file == NULL)
         throw StringError("Could not open file: " + watchOngoingGameInFileName);
       outputEachMove = std::make_unique<std::ofstream>(file);


### PR DESCRIPTION
## Summary

On Windows, if the path in `watchOngoingGameFileName` contains non-ASCII characters, like `D:\Go\跑谱\watchgame.txt`, KataGo fails to open the watch file, and the whole contribute process terminates a few seconds after startup with:
```
ERROR: game loop loop thread failed: Could not open file: D:\Go\跑谱\watchgame.txt
```
The root cause is that the Windows branch opens the file with the narrow-char `fopen_s`, which interprets the UTF-8 path bytes in the ANSI codepage, so the path no longer matches the real directory (a TODO in contribute.cpp already notes that non-ascii paths are unhandled).

This PR converts the path to wide chars and opens it with `_wfopen`, the same pattern already used in `homedata.cpp` and `mainargs.cpp`.

## Testing

Verified on Windows 11 (Chinese locale, GBK codepage), KataGo v1.18.2 + this change, MSVC build with `-DBUILD_DISTRIBUTED=1`:

- A path containing a non-ASCII directory (`D:\Go\跑谱\watchgame.txt`) now creates the file at the correct path. ASCII-only paths behave as before.
- Invalid UTF-8 in the config value produces a clear StringError.